### PR TITLE
Fix vue-router guide link

### DIFF
--- a/src/migration-build.md
+++ b/src/migration-build.md
@@ -196,7 +196,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
 
 10. [Upgrade `vue-router` to v4](https://next.router.vuejs.org/index.html). If you also use `vuex-router-sync`, you can replace it with a store getter.
 
-    After the upgrade, to use `<transition>` and `<keep-alive>` with `<router-view>` requires using the new [scoped-slot based syntax](https://next.router.vuejs.org/index.html#router-view-keep-alive-and-transition).
+    After the upgrade, to use `<transition>` and `<keep-alive>` with `<router-view>` requires using the new [scoped-slot based syntax](https://next.router.vuejs.org/guide/migration/#router-view-keep-alive-and-transition).
 
     [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/758961e73ac4089890079d4ce14996741cf9344b)
 


### PR DESCRIPTION
This PR fixes vue-router guide link URL in migration-build document.
The current link opens vue-router main page.