### PR TITLE
Change vnode-lifecycle-events prefix back to `vnode-`

### DIFF
--- a/src/breaking-changes/vnode-lifecycle-events.md
+++ b/src/breaking-changes/vnode-lifecycle-events.md
@@ -9,7 +9,7 @@ badges:
 
 In Vue 2, it was possible to use events to listen for key stages in a component's lifecycle. These events had names that started with the prefix `hook:`, followed by the name of the corresponding lifecycle hook.
 
-In Vue 3, this prefix has been changed to `vue:`. In addition, these events are now available for HTML elements as well as components.
+In Vue 3, this prefix has been changed to `vnode-`. In addition, these events are now available for HTML elements as well as components.
 
 ## 2.x Syntax
 
@@ -23,11 +23,11 @@ In Vue 2, the event name is the same as the equivalent lifecycle hook, prefixed 
 
 ## 3.x Syntax
 
-In Vue 3, the event name is prefixed with `vue:`:
+In Vue 3, the event name is prefixed with `vnode-`:
 
 ```html
 <template>
-  <child-component @vue:updated="onUpdated">
+  <child-component @vnode-updated="onUpdated">
 </template>
 ```
 


### PR DESCRIPTION
The current documentation is inconsistent with the [@vue/compat](https://github.com/vuejs/core/tree/main/packages/vue-compat) warning which makes things a bit confusing.

Docs currently say the new prefix is `vue:`, while the warning says it's `vnode-`
![image](https://user-images.githubusercontent.com/3198597/190041692-375b82d4-e1b7-4af8-829f-443c3fd09a94.png)

The most info I could find on this is here https://github.com/vuejs/v3-migration-guide/pull/5#pullrequestreview-88802422
> For reference, Vue 3 initially supported vnode- as the prefix. The vue: prefix was added in 3.2.25

To fix the inconsistency, I think the docs should be changed back to `vnode-` (rather than the warnings updated to `vue:`),
since there's a lot of 3rd party material for migrating (not to mention, people's experiences) that can't be updated so easily.

To be clear, in my opinion it was a mistake to change docs from `vnode-` to `vue:`.
Such a fundamental change to the documented breaking changes **after** the community is already migrating, creates fragmentation and confusion. It happened today with a colleague.
In other words, I think we should try to avoid making "breaking changes" to the documented breaking changes.

/cc @skirtles-code 