### PR TITLE
update en doc links to relative path

### DIFF
--- a/src/breaking-changes/async-components.md
+++ b/src/breaking-changes/async-components.md
@@ -95,4 +95,4 @@ const asyncComponent = defineAsyncComponent(
 For more information on the usage of async components, see:
 
 - [Guide: Async Components](https://vuejs.org/guide/components/async.html)
-- [Migration build flag: `COMPONENT_ASYNC`](/migration-build.html#compat-configuration)
+- [Migration build flag: `COMPONENT_ASYNC`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/attribute-coercion.md
+++ b/src/breaking-changes/attribute-coercion.md
@@ -138,7 +138,7 @@ In 3.x, `null` or `undefined` should be used to explicitly remove an attribute.
   </tbody>
 </table>
 
-[Migration build flags:](/migration-build.html#compat-configuration)
+[Migration build flags:](../migration-build.html#compat-configuration)
 
 - `ATTR_FALSE_VALUE`
 - `ATTR_ENUMERATED_COERCION`

--- a/src/breaking-changes/attrs-includes-class-style.md
+++ b/src/breaking-changes/attrs-includes-class-style.md
@@ -60,7 +60,7 @@ when used like this:
 
 In components that use `inheritAttrs: false`, make sure that styling still works as intended. If you previously relied on the special behavior of `class` and `style`, some visuals might be broken as these attributes might now be applied to another element.
 
-[Migration build flag: `INSTANCE_ATTRS_CLASS_STYLE`](/migration-build.html#compat-configuration)
+[Migration build flag: `INSTANCE_ATTRS_CLASS_STYLE`](../migration-build.html#compat-configuration)
 
 ## See also
 

--- a/src/breaking-changes/children.md
+++ b/src/breaking-changes/children.md
@@ -41,4 +41,4 @@ In 3.x, the `$children` property is removed and no longer supported. Instead, if
 
 ## Migration Strategy
 
-[Migration build flag: `INSTANCE_CHILDREN`](/migration-build.html#compat-configuration)
+[Migration build flag: `INSTANCE_CHILDREN`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/custom-directives.md
+++ b/src/breaking-changes/custom-directives.md
@@ -108,4 +108,4 @@ With [fragments](../new/fragments.html#overview) support, components can potenti
 
 ## Migration Strategy
 
-[Migration build flag: `CUSTOM_DIR`](/migration-build.html#compat-configuration)
+[Migration build flag: `CUSTOM_DIR`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/custom-directives.md
+++ b/src/breaking-changes/custom-directives.md
@@ -103,7 +103,7 @@ mounted(el, binding, vnode) {
 ```
 
 :::warning
-With [fragments](/new/fragments.html#overview) support, components can potentially have more than one root node. When applied to a multi-root component, a custom directive will be ignored and a warning will be logged.
+With [fragments](../new/fragments.html#overview) support, components can potentially have more than one root node. When applied to a multi-root component, a custom directive will be ignored and a warning will be logged.
 :::
 
 ## Migration Strategy

--- a/src/breaking-changes/custom-elements-interop.md
+++ b/src/breaking-changes/custom-elements-interop.md
@@ -96,7 +96,7 @@ In 3.0, we are limiting Vue's special treatment of the `is` attribute to the `<c
     document.createElement('button', { is: 'plastic-button' })
     ```
 
-[Migration build flag: `COMPILER_IS_ON_ELEMENT`](/migration-build.html#compat-configuration)
+[Migration build flag: `COMPILER_IS_ON_ELEMENT`](../migration-build.html#compat-configuration)
 
 ## `vue:` Prefix for In-DOM Template Parsing Workarounds
 

--- a/src/breaking-changes/data-option.md
+++ b/src/breaking-changes/data-option.md
@@ -111,7 +111,7 @@ In 3.0, the result will be:
 }
 ```
 
-[Migration build flag: `OPTIONS_DATA_FN`](/migration-build.html#compat-configuration)
+[Migration build flag: `OPTIONS_DATA_FN`](../migration-build.html#compat-configuration)
 
 ## Migration Strategy
 
@@ -122,7 +122,7 @@ For users relying on the object declaration, we recommend:
 
 For users relying on the deep merge behavior from mixins, we recommend refactoring your code to avoid such reliance altogether, since deep merges from mixins are very implicit and can make the code logic more difficult to understand and debug.
 
-[Migration build flags:](/migration-build.html#compat-configuration)
+[Migration build flags:](../migration-build.html#compat-configuration)
 
 - `OPTIONS_DATA_FN`
 - `OPTIONS_DATA_MERGE`

--- a/src/breaking-changes/events-api.md
+++ b/src/breaking-changes/events-api.md
@@ -58,7 +58,7 @@ We removed `$on`, `$off` and `$once` methods from the instance completely. `$emi
 
 ## Migration Strategy
 
-[Migration build flag: `INSTANCE_EVENT_EMITTER`](/migration-build.html#compat-configuration)
+[Migration build flag: `INSTANCE_EVENT_EMITTER`](../migration-build.html#compat-configuration)
 
 In Vue 3, it is no longer possible to use these APIs to listen to a component's own emitted events from within a component. There is no migration path for that use case.
 

--- a/src/breaking-changes/filters.md
+++ b/src/breaking-changes/filters.md
@@ -73,7 +73,7 @@ Using the example above, here is one example of how it could be implemented.
 
 Instead of using filters, we recommend replacing them with computed properties or methods.
 
-[Migration build flags:](/migration-build.html#compat-configuration)
+[Migration build flags:](../migration-build.html#compat-configuration)
 
 - `FILTERS`
 - `COMPILER_FILTERS`

--- a/src/breaking-changes/functional-components.md
+++ b/src/breaking-changes/functional-components.md
@@ -117,4 +117,4 @@ For more information on the usage of the new functional components and the chang
 
 - [Migration: Render Functions](./render-function-api.html)
 - [Guide: Render Functions](https://vuejs.org/guide/extras/render-function.html#render-functions-jsx)
-- [Migration build flag: `COMPONENT_FUNCTIONAL`](/migration-build.html#compat-configuration)
+- [Migration build flag: `COMPONENT_FUNCTIONAL`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/global-api.md
+++ b/src/breaking-changes/global-api.md
@@ -95,7 +95,7 @@ In Vue 3.x, the "use production build" tip will only show up when using the "dev
 
 For ES modules builds, since they are used with bundlers, and in most cases a CLI or boilerplate would have configured the production env properly, this tip will no longer show up.
 
-[Migration build flag: `CONFIG_PRODUCTION_TIP`](/migration-build.html#compat-configuration)
+[Migration build flag: `CONFIG_PRODUCTION_TIP`](../migration-build.html#compat-configuration)
 
 ### `config.ignoredElements` Is Now `config.compilerOptions.isCustomElement`
 
@@ -118,7 +118,7 @@ In Vue 3, the check of whether an element is a component or not has been moved t
 - This will be a new top-level option in the Vue CLI config.
   :::
 
-[Migration build flag: `CONFIG_IGNORED_ELEMENTS`](/migration-build.html#compat-configuration)
+[Migration build flag: `CONFIG_IGNORED_ELEMENTS`](../migration-build.html#compat-configuration)
 
 ### `Vue.prototype` Replaced by `config.globalProperties`
 
@@ -139,7 +139,7 @@ app.config.globalProperties.$http = () => {}
 
 Using `provide` (discussed [below](#provide-inject)) should also be considered as an alternative to `globalProperties`.
 
-[Migration build flag: `GLOBAL_PROTOTYPE`](/migration-build.html#compat-configuration)
+[Migration build flag: `GLOBAL_PROTOTYPE`](../migration-build.html#compat-configuration)
 
 ### `Vue.extend` Removed
 
@@ -189,7 +189,7 @@ Note that although the return type of `defineComponent` is a constructor-like ty
 
 In Vue 3, we strongly recommend favoring composition via [Composition API](https://vuejs.org/guide/reusability/composables.html) over inheritance and mixins. If for some reason you still need component inheritance, you can use the [`extends` option](https://vuejs.org/api/options-composition.html#extends) instead of `Vue.extend`.
 
-[Migration build flag: `GLOBAL_EXTEND`](/migration-build.html#compat-configuration)
+[Migration build flag: `GLOBAL_EXTEND`](../migration-build.html#compat-configuration)
 
 ### A Note for Plugin Authors
 
@@ -244,7 +244,7 @@ app.directive('focus', {
 app.mount('#app')
 ```
 
-[Migration build flag: `GLOBAL_MOUNT`](/migration-build.html#compat-configuration)
+[Migration build flag: `GLOBAL_MOUNT`](../migration-build.html#compat-configuration)
 
 ## Provide / Inject
 

--- a/src/breaking-changes/inline-template-attribute.md
+++ b/src/breaking-changes/inline-template-attribute.md
@@ -30,7 +30,7 @@ This feature will no longer be supported.
 
 Most of the use cases for `inline-template` assumes a no-build-tool setup, where all templates are written directly inside the HTML page.
 
-[Migration build flag: `COMPILER_INLINE_TEMPLATE`](/migration-build.html#compat-configuration)
+[Migration build flag: `COMPILER_INLINE_TEMPLATE`](../migration-build.html#compat-configuration)
 
 ### Option #1: Use `<script>` tag
 

--- a/src/breaking-changes/inline-template-attribute.md
+++ b/src/breaking-changes/inline-template-attribute.md
@@ -81,4 +81,4 @@ The child, instead of providing no template, should now render the default slot\
 </template>
 ```
 
-> - Note: In 3.x, slots can be rendered as the root with native [fragments](/new/fragments) support!
+> - Note: In 3.x, slots can be rendered as the root with native [fragments](../new/fragments) support!

--- a/src/breaking-changes/keycode-modifiers.md
+++ b/src/breaking-changes/keycode-modifiers.md
@@ -66,7 +66,7 @@ The keys for some punctuation marks can just be included literally. e.g. For the
 
 Limitations of the syntax prevent certain characters from being matched, such as `"`, `'`, `/`, `=`, `>`, and `.`. For those characters you should check `event.key` inside the listener instead.
 
-[Migration build flags:](/migration-build.html#compat-configuration)
+[Migration build flags:](../migration-build.html#compat-configuration)
 
 - `CONFIG_KEY_CODES`
 - `V_ON_KEYCODE_MODIFIER`

--- a/src/breaking-changes/listeners-removed.md
+++ b/src/breaking-changes/listeners-removed.md
@@ -65,7 +65,7 @@ If this component received an `id` attribute and a `v-on:close` listener, the `$
 
 Remove all usages of `$listeners`.
 
-[Migration build flag: `INSTANCE_LISTENERS`](/migration-build.html#compat-configuration)
+[Migration build flag: `INSTANCE_LISTENERS`](../migration-build.html#compat-configuration)
 
 ## See also
 

--- a/src/breaking-changes/mount-changes.md
+++ b/src/breaking-changes/mount-changes.md
@@ -91,7 +91,7 @@ When this app is mounted to the page that has a `div` with `id="app"`, this will
 
 ## Migration Strategy
 
-[Migration build flag: `GLOBAL_MOUNT_CONTAINER`](/migration-build.html#compat-configuration)
+[Migration build flag: `GLOBAL_MOUNT_CONTAINER`](../migration-build.html#compat-configuration)
 
 ## See Also
 

--- a/src/breaking-changes/props-default-this.md
+++ b/src/breaking-changes/props-default-this.md
@@ -33,4 +33,4 @@ export default {
 
 ## Migration Strategy
 
-[Migration build flag: `PROPS_DEFAULT_THIS`](/migration-build.html#compat-configuration)
+[Migration build flag: `PROPS_DEFAULT_THIS`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/render-function-api.md
+++ b/src/breaking-changes/render-function-api.md
@@ -131,7 +131,7 @@ For more information, see [The Render Function Api Change RFC](https://github.co
 
 ## Migration Strategy
 
-[Migration build flag: `RENDER_FUNCTION`](/migration-build.html#compat-configuration)
+[Migration build flag: `RENDER_FUNCTION`](../migration-build.html#compat-configuration)
 
 ### Library Authors
 

--- a/src/breaking-changes/slots-unification.md
+++ b/src/breaking-changes/slots-unification.md
@@ -64,4 +64,4 @@ A majority of the change has already been shipped in 2.6. As a result, the migra
 1. Replace all `this.$scopedSlots` occurrences with `this.$slots` in 3.x.
 2. Replace all occurrences of `this.$slots.mySlot` with `this.$slots.mySlot()`
 
-[Migration build flag: `INSTANCE_SCOPED_SLOTS`](/migration-build.html#compat-configuration)
+[Migration build flag: `INSTANCE_SCOPED_SLOTS`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/transition-group.md
+++ b/src/breaking-changes/transition-group.md
@@ -24,7 +24,7 @@ In Vue 2, `<transition-group>`, like other custom components, needed a root elem
 
 ## 3.x Syntax
 
-In Vue 3, we have [fragment support](/new/fragments.html), so components no longer _need_ a root node. Consequently, `<transition-group>` no longer renders one by default.
+In Vue 3, we have [fragment support](../new/fragments.html), so components no longer _need_ a root node. Consequently, `<transition-group>` no longer renders one by default.
 
 - If you already have the `tag` attribute defined in your Vue 2 code, like in the example above, everything will work as before
 - If you didn't have one defined _and_ your styling or other behaviors relied on the presence of the `<span>` root element to work properly, simply add `tag="span"` to the `<transition-group>`:

--- a/src/breaking-changes/transition-group.md
+++ b/src/breaking-changes/transition-group.md
@@ -37,7 +37,7 @@ In Vue 3, we have [fragment support](../new/fragments.html), so components no lo
 
 ## Migration Strategy
 
-[Migration build flag: `TRANSITION_GROUP_ROOT`](/migration-build.html#compat-configuration)
+[Migration build flag: `TRANSITION_GROUP_ROOT`](../migration-build.html#compat-configuration)
 
 ## See also
 

--- a/src/breaking-changes/v-bind.md
+++ b/src/breaking-changes/v-bind.md
@@ -45,4 +45,4 @@ In 3x, if an element has both `v-bind="object"` and an identical individual attr
 
 If you are relying on this override functionality for `v-bind`, we currently recommend ensuring that your `v-bind` attribute is defined before individual attributes.
 
-[Migration build flag: `COMPILER_V_BIND_OBJECT_ORDER`](/migration-build.html#compat-configuration)
+[Migration build flag: `COMPILER_V_BIND_OBJECT_ORDER`](../migration-build.html#compat-configuration)

--- a/src/breaking-changes/v-if-v-for.md
+++ b/src/breaking-changes/v-if-v-for.md
@@ -28,7 +28,7 @@ It is recommended to avoid using both on the same element due to the syntax ambi
 
 Rather than managing this at the template level, one method for accomplishing this is to create a computed property that filters out a list for the visible elements.
 
-[Migration build flag: `COMPILER_V_IF_V_FOR_PRECEDENCE`](/migration-build.html#compat-configuration)
+[Migration build flag: `COMPILER_V_IF_V_FOR_PRECEDENCE`](../migration-build.html#compat-configuration)
 
 ## See also
 

--- a/src/breaking-changes/v-model.md
+++ b/src/breaking-changes/v-model.md
@@ -182,7 +182,7 @@ We recommend:
   }
   ```
 
-[Migration build flags:](/migration-build.html#compat-configuration)
+[Migration build flags:](../migration-build.html#compat-configuration)
 
 - `COMPONENT_V_MODEL`
 - `COMPILER_V_BIND_SYNC`

--- a/src/breaking-changes/v-on-native-modifier-removed.md
+++ b/src/breaking-changes/v-on-native-modifier-removed.md
@@ -49,7 +49,7 @@ Consequently, Vue will now add all event listeners that are _not_ defined as com
 - remove all instances of the `.native` modifier.
 - ensure that all your components document their events with the `emits` option.
 
-[Migration build flag: `COMPILER_V_ON_NATIVE`](/migration-build.html#compat-configuration)
+[Migration build flag: `COMPILER_V_ON_NATIVE`](../migration-build.html#compat-configuration)
 
 ## See also
 

--- a/src/breaking-changes/vnode-lifecycle-events.md
+++ b/src/breaking-changes/vnode-lifecycle-events.md
@@ -35,7 +35,7 @@ In Vue 3, the event name is prefixed with `vue:`:
 
 In most cases it should just require changing the prefix. The lifecycle hooks `beforeDestroy` and `destroyed` have been renamed to `beforeUnmount` and `unmounted` respectively, so the corresponding event names will also need to be updated.
 
-[Migration build flags: `INSTANCE_EVENT_HOOKS`](/migration-build.html#compat-configuration)
+[Migration build flags: `INSTANCE_EVENT_HOOKS`](../migration-build.html#compat-configuration)
 
 ## See Also
 

--- a/src/breaking-changes/watch.md
+++ b/src/breaking-changes/watch.md
@@ -29,4 +29,4 @@ watch: {
 
 If you rely on watching array mutations, add the `deep` option to ensure that your callback is triggered correctly.
 
-[Migration build flag: `WATCH_ARRAY`](/migration-build.html#compat-configuration)
+[Migration build flag: `WATCH_ARRAY`](../migration-build.html#compat-configuration)

--- a/src/index.md
+++ b/src/index.md
@@ -112,7 +112,7 @@ Breaking changes between Vue 2 and Vue 3 are listed [here](./breaking-changes/).
 
 ## New Framework-level Recommendations
 
-New framework-level recommendations are listed [here](/recommendations).
+New framework-level recommendations are listed [here](./recommendations).
 
 ## Migration Build
 

--- a/src/index.md
+++ b/src/index.md
@@ -96,7 +96,7 @@ Some of the new features to keep an eye on in Vue 3 include:
 - [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html)<span class="note">\*</span>
 - [SFC Composition API Syntax Sugar (`<script setup>`)](https://vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
 - [Teleport](https://vuejs.org/guide/built-ins/teleport.html)
-- [Fragments](/new/fragments.html)
+- [Fragments](./new/fragments.html)
 - [Emits Component Option](https://vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
 - [`createRenderer` API from `@vue/runtime-core`](https://vuejs.org/api/custom-renderer.html) to create custom renderers
 - [SFC State-driven CSS Variables (`v-bind` in `<style>`)](https://vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
@@ -108,7 +108,7 @@ Some of the new features to keep an eye on in Vue 3 include:
 
 ## Breaking Changes
 
-Breaking changes between Vue 2 and Vue 3 are listed [here](/breaking-changes/).
+Breaking changes between Vue 2 and Vue 3 are listed [here](./breaking-changes/).
 
 ## New Framework-level Recommendations
 

--- a/src/migration-build.md
+++ b/src/migration-build.md
@@ -184,11 +184,11 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
 
    - If you are using `vue-router`, note `<transition>` and `<keep-alive>` will not work with `<router-view>` until you upgrade to `vue-router` v4.
 
-7. Update [`<transition>` class names](/breaking-changes/transition.html). This is the only feature that does not have a runtime warning. You can do a project-wide search for `.*-enter` and `.*-leave` CSS class names.
+7. Update [`<transition>` class names](./breaking-changes/transition.html). This is the only feature that does not have a runtime warning. You can do a project-wide search for `.*-enter` and `.*-leave` CSS class names.
 
    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/d300103ba622ae26ac26a82cd688e0f70b6c1d8f)
 
-8. Update app entry to use [new global mounting API](/breaking-changes/global-api.html#a-new-global-api-createapp).
+8. Update app entry to use [new global mounting API](./breaking-changes/global-api.html#a-new-global-api-createapp).
 
    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/a6e0c9ac7b1f4131908a4b1e43641f608593f714)
 
@@ -273,71 +273,71 @@ Features that start with `COMPILER_` are compiler-specific: if you are using the
 
 | ID                                    | Type | Description                                                             | Docs                                                                                       |
 | ------------------------------------- | ---- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| GLOBAL_MOUNT_CONTAINER                | ⨂    | Mounted application does not replace the element it's mounted to        | [link](/breaking-changes/mount-changes.html)                                               |
+| GLOBAL_MOUNT_CONTAINER                | ⨂    | Mounted application does not replace the element it's mounted to        | [link](./breaking-changes/mount-changes.html)                                               |
 | CONFIG_DEVTOOLS                       | ⨂    | production devtools is now a build-time flag                            | [link](https://github.com/vuejs/core/tree/master/packages/vue#bundler-build-feature-flags) |
-| COMPILER_V_IF_V_FOR_PRECEDENCE        | ⨂    | `v-if` and `v-for` precedence when used on the same element has changed | [link](/breaking-changes/v-if-v-for.html)                                                  |
-| COMPILER_V_IF_SAME_KEY                | ⨂    | `v-if` branches can no longer have the same key                         | [link](/breaking-changes/key-attribute.html#on-conditional-branches)                       |
-| COMPILER_V_FOR_TEMPLATE_KEY_PLACEMENT | ⨂    | `<template v-for>` key should now be placed on `<template>`             | [link](/breaking-changes/key-attribute.html#with-template-v-for)                           |
-| COMPILER_SFC_FUNCTIONAL               | ⨂    | `<template functional>` is no longer supported in SFCs                  | [link](/breaking-changes/functional-components.html#single-file-components-sfcs)           |
+| COMPILER_V_IF_V_FOR_PRECEDENCE        | ⨂    | `v-if` and `v-for` precedence when used on the same element has changed | [link](./breaking-changes/v-if-v-for.html)                                                  |
+| COMPILER_V_IF_SAME_KEY                | ⨂    | `v-if` branches can no longer have the same key                         | [link](./breaking-changes/key-attribute.html#on-conditional-branches)                       |
+| COMPILER_V_FOR_TEMPLATE_KEY_PLACEMENT | ⨂    | `<template v-for>` key should now be placed on `<template>`             | [link](./breaking-changes/key-attribute.html#with-template-v-for)                           |
+| COMPILER_SFC_FUNCTIONAL               | ⨂    | `<template functional>` is no longer supported in SFCs                  | [link](./breaking-changes/functional-components.html#single-file-components-sfcs)           |
 
 ### Partially Compatible with Caveats
 
 | ID                       | Type | Description                                                                                                                                                                                | Docs                                                                                                           |
 | ------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| CONFIG_IGNORED_ELEMENTS  | ◐    | `config.ignoredElements` is now `config.compilerOptions.isCustomElement` (only in browser compiler build). If using build setup, `isCustomElement` must be passed via build configuration. | [link](/breaking-changes/global-api.html#config-ignoredelements-is-now-config-compileroptions-iscustomelement) |
-| COMPILER_INLINE_TEMPLATE | ◐    | `inline-template` removed (compat only supported in browser compiler build)                                                                                                                | [link](/breaking-changes/inline-template-attribute.html)                                                       |
-| PROPS_DEFAULT_THIS       | ◐    | props default factory no longer have access to `this` (in compat mode, `this` is not a real instance - it only exposes props, `$options` and injections)                                   | [link](/breaking-changes/props-default-this.html)                                                              |
+| CONFIG_IGNORED_ELEMENTS  | ◐    | `config.ignoredElements` is now `config.compilerOptions.isCustomElement` (only in browser compiler build). If using build setup, `isCustomElement` must be passed via build configuration. | [link](./breaking-changes/global-api.html#config-ignoredelements-is-now-config-compileroptions-iscustomelement) |
+| COMPILER_INLINE_TEMPLATE | ◐    | `inline-template` removed (compat only supported in browser compiler build)                                                                                                                | [link](./breaking-changes/inline-template-attribute.html)                                                       |
+| PROPS_DEFAULT_THIS       | ◐    | props default factory no longer have access to `this` (in compat mode, `this` is not a real instance - it only exposes props, `$options` and injections)                                   | [link](./breaking-changes/props-default-this.html)                                                              |
 | INSTANCE_DESTROY         | ◐    | `$destroy` instance method removed (in compat mode, only supported on root instance)                                                                                                       |                                                                                                                |
 | GLOBAL_PRIVATE_UTIL      | ◐    | `Vue.util` is private and no longer available                                                                                                                                              |                                                                                                                |
-| CONFIG_PRODUCTION_TIP    | ◐    | `config.productionTip` no longer necessary                                                                                                                                                 | [link](/breaking-changes/global-api.html#config-productiontip-removed)                                         |
+| CONFIG_PRODUCTION_TIP    | ◐    | `config.productionTip` no longer necessary                                                                                                                                                 | [link](./breaking-changes/global-api.html#config-productiontip-removed)                                         |
 | CONFIG_SILENT            | ◐    | `config.silent` removed                                                                                                                                                                    |                                                                                                                |
 
 ### Compat only (no warning)
 
 | ID                 | Type | Description                            | Docs                                      |
 | ------------------ | ---- | -------------------------------------- | ----------------------------------------- |
-| TRANSITION_CLASSES | ⭘    | Transition enter/leave classes changed | [link](/breaking-changes/transition.html) |
+| TRANSITION_CLASSES | ⭘    | Transition enter/leave classes changed | [link](./breaking-changes/transition.html) |
 
 ### Fully Compatible
 
 | ID                           | Type | Description                                                           | Docs                                                                                        |
 | ---------------------------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| GLOBAL_MOUNT                 | ✔    | new Vue() -> createApp                                                | [link](/breaking-changes/global-api.html#mounting-app-instance)                             |
-| GLOBAL_EXTEND                | ✔    | Vue.extend removed (use `defineComponent` or `extends` option)        | [link](/breaking-changes/global-api.html#vue-extend-removed)                                |
-| GLOBAL_PROTOTYPE             | ✔    | `Vue.prototype` -> `app.config.globalProperties`                      | [link](/breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties) |
+| GLOBAL_MOUNT                 | ✔    | new Vue() -> createApp                                                | [link](./breaking-changes/global-api.html#mounting-app-instance)                             |
+| GLOBAL_EXTEND                | ✔    | Vue.extend removed (use `defineComponent` or `extends` option)        | [link](./breaking-changes/global-api.html#vue-extend-removed)                                |
+| GLOBAL_PROTOTYPE             | ✔    | `Vue.prototype` -> `app.config.globalProperties`                      | [link](./breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties) |
 | GLOBAL_SET                   | ✔    | `Vue.set` removed (no longer needed)                                  |                                                                                             |
 | GLOBAL_DELETE                | ✔    | `Vue.delete` removed (no longer needed)                               |                                                                                             |
 | GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` removed (use `reactive`)                             | [link](https://vuejs.org/api/reactivity-core.html#reactive)                                 |
-| CONFIG_KEY_CODES             | ✔    | config.keyCodes removed                                               | [link](/breaking-changes/keycode-modifiers.html)                                            |
+| CONFIG_KEY_CODES             | ✔    | config.keyCodes removed                                               | [link](./breaking-changes/keycode-modifiers.html)                                            |
 | CONFIG_WHITESPACE            | ✔    | In Vue 3 whitespace defaults to `"condense"`                          |                                                                                             |
 | INSTANCE_SET                 | ✔    | `vm.$set` removed (no longer needed)                                  |                                                                                             |
 | INSTANCE_DELETE              | ✔    | `vm.$delete` removed (no longer needed)                               |                                                                                             |
-| INSTANCE_EVENT_EMITTER       | ✔    | `vm.$on`, `vm.$off`, `vm.$once` removed                               | [link](/breaking-changes/events-api.html)                                                   |
-| INSTANCE_EVENT_HOOKS         | ✔    | Instance no longer emits `hook:x` events                              | [link](/breaking-changes/vnode-lifecycle-events.html)                                       |
-| INSTANCE_CHILDREN            | ✔    | `vm.$children` removed                                                | [link](/breaking-changes/children.html)                                                     |
-| INSTANCE_LISTENERS           | ✔    | `vm.$listeners` removed                                               | [link](/breaking-changes/listeners-removed.html)                                            |
-| INSTANCE_SCOPED_SLOTS        | ✔    | `vm.$scopedSlots` removed; `vm.$slots` now exposes functions          | [link](/breaking-changes/slots-unification.html)                                            |
-| INSTANCE_ATTRS_CLASS_STYLE   | ✔    | `$attrs` now includes `class` and `style`                             | [link](/breaking-changes/attrs-includes-class-style.html)                                   |
-| OPTIONS_DATA_FN              | ✔    | `data` must be a function in all cases                                | [link](/breaking-changes/data-option.html)                                                  |
-| OPTIONS_DATA_MERGE           | ✔    | `data` from mixin or extension is now shallow merged                  | [link](/breaking-changes/data-option.html)                                                  |
+| INSTANCE_EVENT_EMITTER       | ✔    | `vm.$on`, `vm.$off`, `vm.$once` removed                               | [link](./breaking-changes/events-api.html)                                                   |
+| INSTANCE_EVENT_HOOKS         | ✔    | Instance no longer emits `hook:x` events                              | [link](./breaking-changes/vnode-lifecycle-events.html)                                       |
+| INSTANCE_CHILDREN            | ✔    | `vm.$children` removed                                                | [link](./breaking-changes/children.html)                                                     |
+| INSTANCE_LISTENERS           | ✔    | `vm.$listeners` removed                                               | [link](./breaking-changes/listeners-removed.html)                                            |
+| INSTANCE_SCOPED_SLOTS        | ✔    | `vm.$scopedSlots` removed; `vm.$slots` now exposes functions          | [link](./breaking-changes/slots-unification.html)                                            |
+| INSTANCE_ATTRS_CLASS_STYLE   | ✔    | `$attrs` now includes `class` and `style`                             | [link](./breaking-changes/attrs-includes-class-style.html)                                   |
+| OPTIONS_DATA_FN              | ✔    | `data` must be a function in all cases                                | [link](./breaking-changes/data-option.html)                                                  |
+| OPTIONS_DATA_MERGE           | ✔    | `data` from mixin or extension is now shallow merged                  | [link](./breaking-changes/data-option.html)                                                  |
 | OPTIONS_BEFORE_DESTROY       | ✔    | `beforeDestroy` -> `beforeUnmount`                                    |                                                                                             |
 | OPTIONS_DESTROYED            | ✔    | `destroyed` -> `unmounted`                                            |                                                                                             |
-| WATCH_ARRAY                  | ✔    | watching an array no longer triggers on mutation unless deep          | [link](/breaking-changes/watch.html)                                                        |
-| V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` no longer supports keyCode modifiers                           | [link](/breaking-changes/keycode-modifiers.html)                                            |
-| CUSTOM_DIR                   | ✔    | Custom directive hook names changed                                   | [link](/breaking-changes/custom-directives.html)                                            |
-| ATTR_FALSE_VALUE             | ✔    | No longer removes attribute if binding value is boolean `false`       | [link](/breaking-changes/attribute-coercion.html)                                           |
-| ATTR_ENUMERATED_COERCION     | ✔    | No longer special case enumerated attributes                          | [link](/breaking-changes/attribute-coercion.html)                                           |
-| TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` no longer renders a root element by default      | [link](/breaking-changes/transition-group.html)                                             |
-| COMPONENT_ASYNC              | ✔    | Async component API changed (now requires `defineAsyncComponent`)     | [link](/breaking-changes/async-components.html)                                             |
-| COMPONENT_FUNCTIONAL         | ✔    | Functional component API changed (now must be plain functions)        | [link](/breaking-changes/functional-components.html)                                        |
-| COMPONENT_V_MODEL            | ✔    | Component v-model reworked                                            | [link](/breaking-changes/v-model.html)                                                      |
-| RENDER_FUNCTION              | ✔    | Render function API changed                                           | [link](/breaking-changes/render-function-api.html)                                          |
-| FILTERS                      | ✔    | Filters removed (this option affects only runtime filter APIs)        | [link](/breaking-changes/filters.html)                                                      |
-| COMPILER_IS_ON_ELEMENT       | ✔    | `is` usage is now restricted to `<component>` only                    | [link](/breaking-changes/custom-elements-interop.html)                                      |
-| COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` replaced by `v-model` with arguments                    | [link](/breaking-changes/v-model.html)                                                      |
+| WATCH_ARRAY                  | ✔    | watching an array no longer triggers on mutation unless deep          | [link](./breaking-changes/watch.html)                                                        |
+| V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` no longer supports keyCode modifiers                           | [link](./breaking-changes/keycode-modifiers.html)                                            |
+| CUSTOM_DIR                   | ✔    | Custom directive hook names changed                                   | [link](./breaking-changes/custom-directives.html)                                            |
+| ATTR_FALSE_VALUE             | ✔    | No longer removes attribute if binding value is boolean `false`       | [link](./breaking-changes/attribute-coercion.html)                                           |
+| ATTR_ENUMERATED_COERCION     | ✔    | No longer special case enumerated attributes                          | [link](./breaking-changes/attribute-coercion.html)                                           |
+| TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` no longer renders a root element by default      | [link](./breaking-changes/transition-group.html)                                             |
+| COMPONENT_ASYNC              | ✔    | Async component API changed (now requires `defineAsyncComponent`)     | [link](./breaking-changes/async-components.html)                                             |
+| COMPONENT_FUNCTIONAL         | ✔    | Functional component API changed (now must be plain functions)        | [link](./breaking-changes/functional-components.html)                                        |
+| COMPONENT_V_MODEL            | ✔    | Component v-model reworked                                            | [link](./breaking-changes/v-model.html)                                                      |
+| RENDER_FUNCTION              | ✔    | Render function API changed                                           | [link](./breaking-changes/render-function-api.html)                                          |
+| FILTERS                      | ✔    | Filters removed (this option affects only runtime filter APIs)        | [link](./breaking-changes/filters.html)                                                      |
+| COMPILER_IS_ON_ELEMENT       | ✔    | `is` usage is now restricted to `<component>` only                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
+| COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` replaced by `v-model` with arguments                    | [link](./breaking-changes/v-model.html)                                                      |
 | COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` modifier removed                                        |                                                                                             |
-| COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` is now order sensitive                              | [link](/breaking-changes/v-bind.html)                                                       |
-| COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` modifier removed                                        | [link](/breaking-changes/v-on-native-modifier-removed.html)                                 |
+| COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` is now order sensitive                              | [link](./breaking-changes/v-bind.html)                                                       |
+| COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` modifier removed                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
 | COMPILER_V_FOR_REF           | ✔    | `ref` in `v-for` (compiler support)                                   |                                                                                             |
 | COMPILER_NATIVE_TEMPLATE     | ✔    | `<template>` with no special directives now renders as native element |                                                                                             |
 | COMPILER_FILTERS             | ✔    | filters (compiler support)                                            |                                                                                             |


### PR DESCRIPTION
Absolute links are not friendly for translating the guild into other languages. We will have to change them to relative manually one by one. If we both keep relative should be better I think. Thanks.