### PR TITLE
Fix v-model links

### DIFF
--- a/src/breaking-changes/v-model.md
+++ b/src/breaking-changes/v-model.md
@@ -144,7 +144,7 @@ In addition to 2.x hard-coded `v-model` modifiers like `.trim`, now 3.x supports
 <ChildComponent v-model.capitalize="pageTitle" />
 ```
 
-Read more about [custom `v-model` modifiers](https://vuejs.org/guide/components/v-model.html#handling-v-model-modifiers).
+Read more about [custom `v-model` modifiers on components](https://vuejs.org/guide/components/v-model.html#handling-v-model-modifiers).
 
 ## Migration Strategy
 

--- a/src/breaking-changes/v-model.md
+++ b/src/breaking-changes/v-model.md
@@ -144,7 +144,7 @@ In addition to 2.x hard-coded `v-model` modifiers like `.trim`, now 3.x supports
 <ChildComponent v-model.capitalize="pageTitle" />
 ```
 
-Read more about custom `v-model` modifiers in the [Component Events](http://vuejs.org/guide/components/events.html#usage-with-v-model) section.
+Read more about [custom `v-model` modifiers](https://vuejs.org/guide/components/v-model.html#handling-v-model-modifiers).
 
 ## Migration Strategy
 
@@ -191,6 +191,6 @@ We recommend:
 
 For more information on the new `v-model` syntax, see:
 
-- [Using `v-model` on Components](https://vuejs.org/guide/components/events.html#usage-with-v-model)
-- [`v-model` arguments](https://vuejs.org/guide/components/events.html#v-model-arguments)
-- [Handling `v-model` modifiers](https://vuejs.org/guide/components/events.html#usage-with-v-model)
+- [Using `v-model` on Components](https://vuejs.org/guide/components/v-model.html)
+- [`v-model` arguments](https://vuejs.org/guide/components/v-model.html#v-model-arguments)
+- [Handling `v-model` modifiers](https://vuejs.org/guide/components/v-model.html#handling-v-model-modifiers)

--- a/src/zh/breaking-changes/v-model.md
+++ b/src/zh/breaking-changes/v-model.md
@@ -144,7 +144,7 @@ this.$emit('update:title', newValue)
 <ChildComponent v-model.capitalize="pageTitle" />
 ```
 
-我们可以在[组件事件](http://cn.vuejs.org/guide/components/events.html#usage-with-v-model)部分中了解有关自定义 `v-model` 修饰符的更多信息。
+[自定义 `v-model` 修饰符](https://cn.vuejs.org/guide/components/v-model.html)的更多信息。
 
 ## 迁移策略
 
@@ -191,6 +191,6 @@ this.$emit('update:title', newValue)
 
 更多新的 `v-model` 语法相关信息，请参考：
 
-- [在组件中使用 `v-model`](https://cn.vuejs.org/guide/components/events.html#usage-with-v-model) 
-- [`v-model` 参数](https://cn.vuejs.org/guide/components/events.html#v-model-arguments)
-- [处理 `v-model` 修饰符](https://cn.vuejs.org/guide/components/events.html#usage-with-v-model)
+- [在组件中使用 `v-model`](https://cn.vuejs.org/guide/components/v-model.html) 
+- [`v-model` 参数](https://cn.vuejs.org/guide/components/v-model.html#v-model-arguments)
+- [处理 `v-model` 修饰符](https://cn.vuejs.org/guide/components/v-model.html#handling-v-model-modifiers)

--- a/src/zh/breaking-changes/v-model.md
+++ b/src/zh/breaking-changes/v-model.md
@@ -144,7 +144,7 @@ this.$emit('update:title', newValue)
 <ChildComponent v-model.capitalize="pageTitle" />
 ```
 
-[自定义 `v-model` 修饰符](https://cn.vuejs.org/guide/components/v-model.html)的更多信息。
+查阅关于[组件上的自定义 `v-model` 修饰符](https://cn.vuejs.org/guide/components/v-model.html)的更多信息。
 
 ## 迁移策略
 


### PR DESCRIPTION
Fix v-model links to avoid redirecting.
The event page was divided. https://github.com/vuejs/docs/pull/2153
