### PR TITLE
Japanese translation (Guide section)

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -6,13 +6,14 @@ import locales from "./locales"
 export default {
   srcDir: 'src',
   locales: locales.vitepressConfig,
-  
+
 
   themeConfig: {
     localeLinks: {
       items: [
         {text: 'English', link: '/'},
-        {text: '中文简体 (未完成)', link: '/zh/'}
+        {text: '中文简体 (未完成)', link: '/zh/'},
+        {text: '日本語（未完成）', link: '/ja/'},
       ]
     },
     locales: locales.themeConfig

--- a/.vitepress/locales/index.js
+++ b/.vitepress/locales/index.js
@@ -1,13 +1,16 @@
 import en from './en'
 import zh from './zh'
+import ja from './ja'
 
 export default {
   vitepressConfig: {
     '/': en.vitepressConfig,
-    '/zh/': zh.vitepressConfig
+    '/zh/': zh.vitepressConfig,
+    '/ja/': ja.vitepressConfig,
   },
   themeConfig: {
     '/': en.themeConfig,
-    '/zh/': zh.themeConfig
+    '/zh/': zh.themeConfig,
+    '/ja/': ja.themeConfig,
   }
 }

--- a/.vitepress/locales/ja.js
+++ b/.vitepress/locales/ja.js
@@ -1,24 +1,29 @@
 export default {
   vitepressConfig: {
-    title: 'Vue 3 Migration Guide',
-    description: 'Guide on migrating from Vue 2 to Vue 3',
-    lang: 'en-US'
+    title: 'Vue 3 移行ガイド',
+    description: 'Vue 2 から Vue 3 への移行に関するガイド',
+    lang: 'ja-JP',
   },
   themeConfig: {
+    docFooter: {
+      prev: '前のページ',
+      next: '次のページ',
+    },
+    outlineTitle: 'ページの内容',
     nav: [
-      { text: 'Vue 3 Docs', link: 'https://vuejs.org' },
+      { text: 'Vue 3 ドキュメント', link: 'https://ja.vuejs.org' },
     ],
 
     sidebar: [
       {
         text: 'Guide',
         items: [
-          { text: 'Overview', link: '/' },
-          { text: 'New Recommendations', link: '/recommendations' },
-          { text: 'Migration Build', link: '/migration-build' },
+          { text: 'Overview', link: '/ja/' },
+          { text: 'New Recommendations', link: '/ja/recommendations' },
+          { text: 'Migration Build', link: '/ja/migration-build' },
           {
             text: 'Breaking Changes',
-            link: '/breaking-changes/'
+            link: '/ja/breaking-changes/'
           }
         ]
       },
@@ -27,30 +32,30 @@ export default {
         items: [
           {
             text: 'Global API Application Instance',
-            link: '/breaking-changes/global-api'
+            link: '/ja/breaking-changes/global-api'
           },
           {
             text: 'Global API Treeshaking',
-            link: '/breaking-changes/global-api-treeshaking'
+            link: '/ja/breaking-changes/global-api-treeshaking'
           }
         ]
       },
       {
         text: 'Template Directives',
         items: [
-          { text: 'v-model', link: '/breaking-changes/v-model' },
+          { text: 'v-model', link: '/ja/breaking-changes/v-model' },
           {
             text: 'key Usage Change',
-            link: '/breaking-changes/key-attribute'
+            link: '/ja/breaking-changes/key-attribute'
           },
           {
             text: 'v-if vs. v-for Precedence',
-            link: '/breaking-changes/v-if-v-for'
+            link: '/ja/breaking-changes/v-if-v-for'
           },
-          { text: 'v-bind Merge Behavior', link: '/breaking-changes/v-bind' },
+          { text: 'v-bind Merge Behavior', link: '/ja/breaking-changes/v-bind' },
           {
             text: 'v-on.native modifier removed',
-            link: '/breaking-changes/v-on-native-modifier-removed'
+            link: '/ja/breaking-changes/v-on-native-modifier-removed'
           }
         ]
       },
@@ -59,13 +64,13 @@ export default {
         items: [
           {
             text: 'Functional Components',
-            link: '/breaking-changes/functional-components'
+            link: '/ja/breaking-changes/functional-components'
           },
           {
             text: 'Async Components',
-            link: '/breaking-changes/async-components'
+            link: '/ja/breaking-changes/async-components'
           },
-          { text: 'emits Option', link: '/breaking-changes/emits-option' }
+          { text: 'emits Option', link: '/ja/breaking-changes/emits-option' }
         ]
       },
       {
@@ -73,19 +78,19 @@ export default {
         items: [
           {
             text: 'Render Function API',
-            link: '/breaking-changes/render-function-api'
+            link: '/ja/breaking-changes/render-function-api'
           },
           {
             text: 'Slots Unification',
-            link: '/breaking-changes/slots-unification'
+            link: '/ja/breaking-changes/slots-unification'
           },
           {
             text: '$listeners merged into $attrs',
-            link: '/breaking-changes/listeners-removed'
+            link: '/ja/breaking-changes/listeners-removed'
           },
           {
             text: '$attrs includes class & style',
-            link: '/breaking-changes/attrs-includes-class-style'
+            link: '/ja/breaking-changes/attrs-includes-class-style'
           }
         ]
       },
@@ -94,7 +99,7 @@ export default {
         items: [
           {
             text: 'Custom Elements Interop Changes',
-            link: '/breaking-changes/custom-elements-interop'
+            link: '/ja/breaking-changes/custom-elements-interop'
           }
         ]
       },
@@ -103,16 +108,16 @@ export default {
         items: [
           {
             text: 'v-on keyCode Modifiers',
-            link: '/breaking-changes/keycode-modifiers'
+            link: '/ja/breaking-changes/keycode-modifiers'
           },
-          { text: 'Events API', link: '/breaking-changes/events-api' },
-          { text: 'Filters', link: '/breaking-changes/filters' },
+          { text: 'Events API', link: '/ja/breaking-changes/events-api' },
+          { text: 'Filters', link: '/ja/breaking-changes/filters' },
           {
             text: 'inline-template',
-            link: '/breaking-changes/inline-template-attribute'
+            link: '/ja/breaking-changes/inline-template-attribute'
           },
-          { text: '$children', link: '/breaking-changes/children' },
-          { text: 'propsData option', link: '/breaking-changes/props-data' }
+          { text: '$children', link: '/ja/breaking-changes/children' },
+          { text: 'propsData option', link: '/ja/breaking-changes/props-data' }
         ]
       },
       {
@@ -120,38 +125,38 @@ export default {
         items: [
           {
             text: 'Attribute Coercion Behavior',
-            link: '/breaking-changes/attribute-coercion'
+            link: '/ja/breaking-changes/attribute-coercion'
           },
           {
             text: 'Custom Directives',
-            link: '/breaking-changes/custom-directives'
+            link: '/ja/breaking-changes/custom-directives'
           },
-          { text: 'Data Option', link: '/breaking-changes/data-option' },
+          { text: 'Data Option', link: '/ja/breaking-changes/data-option' },
           {
             text: 'Mount API changes',
-            link: '/breaking-changes/mount-changes'
+            link: '/ja/breaking-changes/mount-changes'
           },
           {
             text: 'Props Default Function this Access',
-            link: '/breaking-changes/props-default-this'
+            link: '/ja/breaking-changes/props-default-this'
           },
           {
             text: 'Transition Class Change',
-            link: '/breaking-changes/transition'
+            link: '/ja/breaking-changes/transition'
           },
           {
             text: 'Transition as Root',
-            link: '/breaking-changes/transition-as-root'
+            link: '/ja/breaking-changes/transition-as-root'
           },
           {
             text: 'Transition Group Root Element',
-            link: '/breaking-changes/transition-group'
+            link: '/ja/breaking-changes/transition-group'
           },
           {
             text: 'VNode lifecycle events',
-            link: '/breaking-changes/vnode-lifecycle-events'
+            link: '/ja/breaking-changes/vnode-lifecycle-events'
           },
-          { text: 'Watch on Arrays', link: '/breaking-changes/watch' }
+          { text: 'Watch on Arrays', link: '/ja/breaking-changes/watch' }
         ]
       }
     ]

--- a/.vitepress/locales/ja.js
+++ b/.vitepress/locales/ja.js
@@ -16,13 +16,13 @@ export default {
 
     sidebar: [
       {
-        text: 'Guide',
+        text: 'ガイド',
         items: [
-          { text: 'Overview', link: '/ja/' },
-          { text: 'New Recommendations', link: '/ja/recommendations' },
-          { text: 'Migration Build', link: '/ja/migration-build' },
+          { text: '概要', link: '/ja/' },
+          { text: '新しい推奨事項', link: '/ja/recommendations' },
+          { text: '移行ビルド', link: '/ja/migration-build' },
           {
-            text: 'Breaking Changes',
+            text: '破壊的変更',
             link: '/ja/breaking-changes/'
           }
         ]

--- a/.vitepress/locales/ja.js
+++ b/.vitepress/locales/ja.js
@@ -1,0 +1,159 @@
+export default {
+  vitepressConfig: {
+    title: 'Vue 3 Migration Guide',
+    description: 'Guide on migrating from Vue 2 to Vue 3',
+    lang: 'en-US'
+  },
+  themeConfig: {
+    nav: [
+      { text: 'Vue 3 Docs', link: 'https://vuejs.org' },
+    ],
+
+    sidebar: [
+      {
+        text: 'Guide',
+        items: [
+          { text: 'Overview', link: '/' },
+          { text: 'New Recommendations', link: '/recommendations' },
+          { text: 'Migration Build', link: '/migration-build' },
+          {
+            text: 'Breaking Changes',
+            link: '/breaking-changes/'
+          }
+        ]
+      },
+      {
+        text: 'Global API',
+        items: [
+          {
+            text: 'Global API Application Instance',
+            link: '/breaking-changes/global-api'
+          },
+          {
+            text: 'Global API Treeshaking',
+            link: '/breaking-changes/global-api-treeshaking'
+          }
+        ]
+      },
+      {
+        text: 'Template Directives',
+        items: [
+          { text: 'v-model', link: '/breaking-changes/v-model' },
+          {
+            text: 'key Usage Change',
+            link: '/breaking-changes/key-attribute'
+          },
+          {
+            text: 'v-if vs. v-for Precedence',
+            link: '/breaking-changes/v-if-v-for'
+          },
+          { text: 'v-bind Merge Behavior', link: '/breaking-changes/v-bind' },
+          {
+            text: 'v-on.native modifier removed',
+            link: '/breaking-changes/v-on-native-modifier-removed'
+          }
+        ]
+      },
+      {
+        text: 'Components',
+        items: [
+          {
+            text: 'Functional Components',
+            link: '/breaking-changes/functional-components'
+          },
+          {
+            text: 'Async Components',
+            link: '/breaking-changes/async-components'
+          },
+          { text: 'emits Option', link: '/breaking-changes/emits-option' }
+        ]
+      },
+      {
+        text: 'Render Function',
+        items: [
+          {
+            text: 'Render Function API',
+            link: '/breaking-changes/render-function-api'
+          },
+          {
+            text: 'Slots Unification',
+            link: '/breaking-changes/slots-unification'
+          },
+          {
+            text: '$listeners merged into $attrs',
+            link: '/breaking-changes/listeners-removed'
+          },
+          {
+            text: '$attrs includes class & style',
+            link: '/breaking-changes/attrs-includes-class-style'
+          }
+        ]
+      },
+      {
+        text: 'Custom Elements',
+        items: [
+          {
+            text: 'Custom Elements Interop Changes',
+            link: '/breaking-changes/custom-elements-interop'
+          }
+        ]
+      },
+      {
+        text: 'Removed APIs',
+        items: [
+          {
+            text: 'v-on keyCode Modifiers',
+            link: '/breaking-changes/keycode-modifiers'
+          },
+          { text: 'Events API', link: '/breaking-changes/events-api' },
+          { text: 'Filters', link: '/breaking-changes/filters' },
+          {
+            text: 'inline-template',
+            link: '/breaking-changes/inline-template-attribute'
+          },
+          { text: '$children', link: '/breaking-changes/children' },
+          { text: 'propsData option', link: '/breaking-changes/props-data' }
+        ]
+      },
+      {
+        text: 'Other Minor Changes',
+        items: [
+          {
+            text: 'Attribute Coercion Behavior',
+            link: '/breaking-changes/attribute-coercion'
+          },
+          {
+            text: 'Custom Directives',
+            link: '/breaking-changes/custom-directives'
+          },
+          { text: 'Data Option', link: '/breaking-changes/data-option' },
+          {
+            text: 'Mount API changes',
+            link: '/breaking-changes/mount-changes'
+          },
+          {
+            text: 'Props Default Function this Access',
+            link: '/breaking-changes/props-default-this'
+          },
+          {
+            text: 'Transition Class Change',
+            link: '/breaking-changes/transition'
+          },
+          {
+            text: 'Transition as Root',
+            link: '/breaking-changes/transition-as-root'
+          },
+          {
+            text: 'Transition Group Root Element',
+            link: '/breaking-changes/transition-group'
+          },
+          {
+            text: 'VNode lifecycle events',
+            link: '/breaking-changes/vnode-lifecycle-events'
+          },
+          { text: 'Watch on Arrays', link: '/breaking-changes/watch' }
+        ]
+      }
+    ]
+  }
+}

--- a/src/ja/breaking-changes/async-components.md
+++ b/src/ja/breaking-changes/async-components.md
@@ -94,5 +94,5 @@ const asyncComponent = defineAsyncComponent(
 
 For more information on the usage of async components, see:
 
-- [Guide: Async Components](https://vuejs.org/guide/components/async.html)
+- [Guide: Async Components](https://ja.vuejs.org/guide/components/async.html)
 - [Migration build flag: `COMPONENT_ASYNC`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/async-components.md
+++ b/src/ja/breaking-changes/async-components.md
@@ -1,0 +1,98 @@
+---
+badges:
+  - new
+---
+
+# Async Components <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Here is a high level overview of what has changed:
+
+- New `defineAsyncComponent` helper method that explicitly defines async components
+- `component` option renamed to `loader`
+- Loader function does not inherently receive `resolve` and `reject` arguments and must return a Promise
+
+For a more in-depth explanation, read on!
+
+## Introduction
+
+Previously, async components were created by simply defining a component as a function that returned a promise, such as:
+
+```js
+const asyncModal = () => import('./Modal.vue')
+```
+
+Or, for the more advanced component syntax with options:
+
+```js
+const asyncModal = {
+  component: () => import('./Modal.vue'),
+  delay: 200,
+  timeout: 3000,
+  error: ErrorComponent,
+  loading: LoadingComponent
+}
+```
+
+## 3.x Syntax
+
+Now, in Vue 3, since functional components are defined as pure functions, async components definitions need to be explicitly defined by wrapping it in a new `defineAsyncComponent` helper:
+
+```js
+import { defineAsyncComponent } from 'vue'
+import ErrorComponent from './components/ErrorComponent.vue'
+import LoadingComponent from './components/LoadingComponent.vue'
+
+// Async component without options
+const asyncModal = defineAsyncComponent(() => import('./Modal.vue'))
+
+// Async component with options
+const asyncModalWithOptions = defineAsyncComponent({
+  loader: () => import('./Modal.vue'),
+  delay: 200,
+  timeout: 3000,
+  errorComponent: ErrorComponent,
+  loadingComponent: LoadingComponent
+})
+```
+
+::: tip NOTE
+Vue Router supports a similar mechanism for asynchronously loading route components, known as *lazy loading*. Despite the similarities, this feature is distinct from Vue's support for async components. You should **not** use `defineAsyncComponent` when configuring route components with Vue Router. You can read more about this in the [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) section of the Vue Router documentation.
+:::
+
+Another change that has been made from 2.x is that the `component` option is now renamed to `loader` in order to accurately communicate that a component definition cannot be provided directly.
+
+```js{4}
+import { defineAsyncComponent } from 'vue'
+
+const asyncModalWithOptions = defineAsyncComponent({
+  loader: () => import('./Modal.vue'),
+  delay: 200,
+  timeout: 3000,
+  errorComponent: ErrorComponent,
+  loadingComponent: LoadingComponent
+})
+```
+
+In addition, unlike 2.x, the loader function no longer receives the `resolve` and `reject` arguments and must always return a Promise.
+
+```js
+// 2.x version
+const oldAsyncComponent = (resolve, reject) => {
+  /* ... */
+}
+
+// 3.x version
+const asyncComponent = defineAsyncComponent(
+  () =>
+    new Promise((resolve, reject) => {
+      /* ... */
+    })
+)
+```
+
+For more information on the usage of async components, see:
+
+- [Guide: Async Components](https://vuejs.org/guide/components/async.html)
+- [Migration build flag: `COMPONENT_ASYNC`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/attribute-coercion.md
+++ b/src/ja/breaking-changes/attribute-coercion.md
@@ -1,0 +1,144 @@
+---
+badges:
+  - breaking
+---
+
+# Attribute Coercion Behavior <MigrationBadges :badges="$frontmatter.badges" />
+
+::: info Info
+This is a low-level internal API change and does not affect most developers.
+:::
+
+## Overview
+
+Here is a high level summary of the changes:
+
+- Drop the internal concept of enumerated attributes and treat those attributes the same as normal non-boolean attributes
+- **BREAKING**: No longer removes attribute if the value is boolean `false`. Instead, it's set as attr="false". To remove the attribute, use `null` or `undefined`.
+
+For more information, read on!
+
+## 2.x Syntax
+
+In 2.x, we had the following strategies for coercing `v-bind` values:
+
+- For some attribute/element pairs, Vue is always using the corresponding IDL attribute (property): [like `value` of `<input>`, `<select>`, `<progress>`, etc](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L11-L18).
+
+- For "[boolean attributes](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L33-L40)" and [xlinks](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L44-L46), Vue removes them if they are "falsy" ([`undefined`, `null` or `false`](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L52-L54)) and adds them otherwise (see [here](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L66-L77) and [here](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L81-L85)).
+
+- For "[enumerated attributes](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L20)" (currently `contenteditable`, `draggable` and `spellcheck`), Vue tries to [coerce](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/util/attrs.js#L24-L31) them to string (with special treatment for `contenteditable` for now, to fix [vuejs/vue#9397](https://github.com/vuejs/vue/issues/9397)).
+
+- For other attributes, we remove "falsy" values (`undefined`, `null`, or `false`) and set other values as-is (see [here](https://github.com/vuejs/vue/blob/bad3c326a3f8b8e0d3bcf07917dc0adf97c32351/src/platforms/web/runtime/modules/attrs.js#L92-L113)).
+
+The following table describes how Vue coerce "enumerated attributes" differently with normal non-boolean attributes:
+
+| Binding expression  | `foo` <sup>normal</sup> | `draggable` <sup>enumerated</sup> |
+| ------------------- | ----------------------- | --------------------------------- |
+| `:attr="null"`      | -                       | `draggable="false"`               |
+| `:attr="undefined"` | -                       | -                                 |
+| `:attr="true"`      | `foo="true"`            | `draggable="true"`                |
+| `:attr="false"`     | -                       | `draggable="false"`               |
+| `:attr="0"`         | `foo="0"`               | `draggable="true"`                |
+| `attr=""`           | `foo=""`                | `draggable="true"`                |
+| `attr="foo"`        | `foo="foo"`             | `draggable="true"`                |
+| `attr`              | `foo=""`                | `draggable="true"`                |
+
+We can see from the table above, current implementation coerces `true` to `'true'` but removes the attribute if it's `false`. This also led to inconsistency and required users to manually coerce boolean values to string in very common use cases like `aria-*` attributes like `aria-selected`, `aria-hidden`, etc.
+
+## 3.x Syntax
+
+We intend to drop this internal concept of "enumerated attributes" and treat them as normal non-boolean HTML attributes.
+
+- This solves the inconsistency between normal non-boolean attributes and “enumerated attributes”
+- It also makes it possible to use values other than `'true'` and `'false'`, or even keywords yet to come, for attributes like `contenteditable`
+
+For non-boolean attributes, Vue will stop removing them if they are `false` and coerce them to `'false'` instead.
+
+- This solves the inconsistency between `true` and `false` and makes outputting `aria-*` attributes easier
+
+The following table describes the new behavior:
+
+| Binding expression  | `foo` <sup>normal</sup>    | `draggable` <sup>enumerated</sup> |
+| ------------------- | -------------------------- | --------------------------------- |
+| `:attr="null"`      | -                          | - <sup>*</sup>                    |
+| `:attr="undefined"` | -                          | -                                 |
+| `:attr="true"`      | `foo="true"`               | `draggable="true"`                |
+| `:attr="false"`     | `foo="false"` <sup>*</sup> | `draggable="false"`               |
+| `:attr="0"`         | `foo="0"`                  | `draggable="0"` <sup>*</sup>      |
+| `attr=""`           | `foo=""`                   | `draggable=""` <sup>*</sup>       |
+| `attr="foo"`        | `foo="foo"`                | `draggable="foo"` <sup>*</sup>    |
+| `attr`              | `foo=""`                   | `draggable=""` <sup>*</sup>       |
+
+<small>*: changed</small>
+
+Coercion for boolean attributes is left untouched.
+
+## Migration Strategy
+
+### Enumerated attributes
+
+The absence of an enumerated attribute and `attr="false"` may produce different IDL attribute values (which will reflect the actual state), described as follows:
+
+| Absent enumerated attr | IDL attr & value                     |
+| ---------------------- | ------------------------------------ |
+| `contenteditable`      | `contentEditable` &rarr; `'inherit'` |
+| `draggable`            | `draggable` &rarr; `false`           |
+| `spellcheck`           | `spellcheck` &rarr; `true`           |
+
+Since we no longer coerce `null` to `'false'` for “enumerated properties” in 3.x, in the case of `contenteditable` and `spellcheck`, developers will need to change those `v-bind` expressions that used to resolve to `null` to resolve to `false` or `'false'` in order to maintain the same behavior as 2.x.
+
+In 2.x, invalid values were coerced to `'true'` for enumerated attributes. This was usually unintended and unlikely to be relied upon on a large scale. In 3.x `true` or `'true'` should be explicitly specified.
+
+### Coercing `false` to `'false'` instead of removing the attribute
+
+In 3.x, `null` or `undefined` should be used to explicitly remove an attribute.
+
+### Comparison between 2.x & 3.x behavior
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th><code>v-bind</code> value <sup>2.x</sup></th>
+      <th><code>v-bind</code> value <sup>3.x</sup></th>
+      <th>HTML output</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3">2.x “Enumerated attrs”<br><small>i.e. <code>contenteditable</code>, <code>draggable</code> and <code>spellcheck</code>.</small></td>
+      <td><code>undefined</code></td>
+      <td><code>undefined</code>, <code>null</code></td>
+      <td><i>removed</i></td>
+    </tr>
+    <tr>
+      <td>
+        <code>true</code>, <code>'true'</code>, <code>''</code>, <code>1</code>,
+        <code>'foo'</code>
+      </td>
+      <td><code>true</code>, <code>'true'</code></td>
+      <td><code>"true"</code></td>
+    </tr>
+    <tr>
+      <td><code>null</code>, <code>false</code>, <code>'false'</code></td>
+      <td><code>false</code>, <code>'false'</code></td>
+      <td><code>"false"</code></td>
+    </tr>
+    <tr>
+      <td rowspan="2">Other non-boolean attrs<br><small>eg. <code>aria-checked</code>, <code>tabindex</code>, <code>alt</code>, etc.</small></td>
+      <td><code>undefined</code>, <code>null</code>, <code>false</code></td>
+      <td><code>undefined</code>, <code>null</code></td>
+      <td><i>removed</i></td>
+    </tr>
+    <tr>
+      <td><code>'false'</code></td>
+      <td><code>false</code>, <code>'false'</code></td>
+      <td><code>"false"</code></td>
+    </tr>
+  </tbody>
+</table>
+
+[Migration build flags:](../migration-build.html#compat-configuration)
+
+- `ATTR_FALSE_VALUE`
+- `ATTR_ENUMERATED_COERCION`

--- a/src/ja/breaking-changes/attrs-includes-class-style.md
+++ b/src/ja/breaking-changes/attrs-includes-class-style.md
@@ -1,0 +1,71 @@
+---
+title: $attrs includes class & style
+badges:
+  - breaking
+---
+
+# `$attrs` includes `class` & `style` <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+`$attrs` now contains _all_ attributes passed to a component, including `class` and `style`.
+
+## 2.x Behavior
+
+`class` and `style` attributes get some special handling in the Vue 2 virtual DOM implementation. For that reason, they are _not_ included in `$attrs`, while all other attributes are.
+
+A side effect of this manifests when using `inheritAttrs: false`:
+
+- Attributes in `$attrs` are no longer automatically added to the root element, leaving it to the developer to decide where to add them.
+- But `class` and `style`, not being part of `$attrs`, will still be applied to the component's root element:
+
+```vue
+<template>
+  <label>
+    <input type="text" v-bind="$attrs" />
+  </label>
+</template>
+<script>
+export default {
+  inheritAttrs: false
+}
+</script>
+```
+
+when used like this:
+
+```html
+<my-component id="my-id" class="my-class"></my-component>
+```
+
+...will generate this HTML:
+
+```html
+<label class="my-class">
+  <input type="text" id="my-id" />
+</label>
+```
+
+## 3.x Behavior
+
+`$attrs` contains _all_ attributes, which makes it easier to apply all of them to a different element. The example from above now generates the following HTML:
+
+```html
+<label>
+  <input type="text" id="my-id" class="my-class" />
+</label>
+```
+
+## Migration Strategy
+
+In components that use `inheritAttrs: false`, make sure that styling still works as intended. If you previously relied on the special behavior of `class` and `style`, some visuals might be broken as these attributes might now be applied to another element.
+
+[Migration build flag: `INSTANCE_ATTRS_CLASS_STYLE`](../migration-build.html#compat-configuration)
+
+## See also
+
+- [Relevant RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
+- [Migration guide - `$listeners` removed](./listeners-removed.md)
+- [Migration guide - New Emits Option](./emits-option.md)
+- [Migration guide - `.native` modifier removed](./v-on-native-modifier-removed.md)
+- [Migration guide - Changes in the Render Functions API](./render-function-api.md)

--- a/src/ja/breaking-changes/children.md
+++ b/src/ja/breaking-changes/children.md
@@ -37,7 +37,7 @@ export default {
 
 ## 3.x Update
 
-In 3.x, the `$children` property is removed and no longer supported. Instead, if you need to access a child component instance, we recommend using [template refs](https://vuejs.org/guide/essentials/template-refs.html#template-refs).
+In 3.x, the `$children` property is removed and no longer supported. Instead, if you need to access a child component instance, we recommend using [template refs](https://ja.vuejs.org/guide/essentials/template-refs.html#template-refs).
 
 ## Migration Strategy
 

--- a/src/ja/breaking-changes/children.md
+++ b/src/ja/breaking-changes/children.md
@@ -1,0 +1,44 @@
+---
+badges:
+  - removed
+---
+
+# $children <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The `$children` instance property has been removed from Vue 3.0 and is no longer supported.
+
+## 2.x Syntax
+
+In 2.x, developers could access direct child components of the current instance with `this.$children`:
+
+```vue
+<template>
+  <div>
+    <img alt="Vue logo" src="./assets/logo.png">
+    <my-button>Change logo</my-button>
+  </div>
+</template>
+
+<script>
+import MyButton from './MyButton'
+
+export default {
+  components: {
+    MyButton
+  },
+  mounted() {
+    console.log(this.$children) // [VueComponent]
+  }
+}
+</script>
+```
+
+## 3.x Update
+
+In 3.x, the `$children` property is removed and no longer supported. Instead, if you need to access a child component instance, we recommend using [template refs](https://vuejs.org/guide/essentials/template-refs.html#template-refs).
+
+## Migration Strategy
+
+[Migration build flag: `INSTANCE_CHILDREN`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/custom-directives.md
+++ b/src/ja/breaking-changes/custom-directives.md
@@ -1,0 +1,111 @@
+---
+badges:
+  - breaking
+---
+
+# Custom Directives <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The hook functions for directives have been renamed to better align with the component lifecycle.
+
+Additionally, the `expression` string is no longer passed as part of the `binding` object.
+
+## 2.x Syntax
+
+In Vue 2, custom directives were created by using the hooks listed below to target an element’s lifecycle, all of which are optional:
+
+- **bind** - Called once the directive is bound to the element. Called only once.
+- **inserted** - Called once the element is inserted into the parent DOM.
+- **update** - This hook is called when the element updates, but children haven't been updated yet.
+- **componentUpdated** - This hook is called once the component and the children have been updated.
+- **unbind** - This hook is called once the directive is removed. Also called only once.
+
+Here’s an example of this:
+
+```html
+<p v-highlight="'yellow'">Highlight this text bright yellow</p>
+```
+
+```js
+Vue.directive('highlight', {
+  bind(el, binding, vnode) {
+    el.style.background = binding.value
+  }
+})
+```
+
+Here, in the initial setup for this element, the directive binds a style by passing in a value, that can be updated to different values through the application.
+
+## 3.x Syntax
+
+In Vue 3, however, we’ve created a more cohesive API for custom directives. As you can see, they differ greatly from our component lifecycle methods even though we’re hooking into similar events. We’ve now unified them like so:
+
+- **created** - new! This is called before the element's attributes or event listeners are applied.
+- bind → **beforeMount**
+- inserted → **mounted**
+- **beforeUpdate**: new! This is called before the element itself is updated, much like the component lifecycle hooks.
+- update → removed! There were too many similarities to `updated`, so this is redundant. Please use `updated` instead.
+- componentUpdated → **updated**
+- **beforeUnmount**: new! Similar to component lifecycle hooks, this will be called right before an element is unmounted.
+- unbind -> **unmounted**
+
+The final API is as follows:
+
+```js
+const MyDirective = {
+  created(el, binding, vnode, prevVnode) {}, // new
+  beforeMount() {},
+  mounted() {},
+  beforeUpdate() {}, // new
+  updated() {},
+  beforeUnmount() {}, // new
+  unmounted() {}
+}
+```
+
+The resulting API could be used like this, mirroring the example from earlier:
+
+```html
+<p v-highlight="'yellow'">Highlight this text bright yellow</p>
+```
+
+```js
+const app = Vue.createApp({})
+
+app.directive('highlight', {
+  beforeMount(el, binding, vnode) {
+    el.style.background = binding.value
+  }
+})
+```
+
+Now that the custom directive lifecycle hooks mirror those of the components themselves, they become easier to reason about and remember!
+
+### Edge Case: Accessing the component instance
+
+It's generally recommended to keep directives independent of the component instance they are used in. Accessing the instance from within a custom directive is often a sign that the directive should rather be a component itself. However, there are situations where this actually makes sense.
+
+In Vue 2, the component instance had to be accessed through the `vnode` argument:
+
+```js
+bind(el, binding, vnode) {
+  const vm = vnode.context
+}
+```
+
+In Vue 3, the instance is now part of the `binding`:
+
+```js
+mounted(el, binding, vnode) {
+  const vm = binding.instance
+}
+```
+
+:::warning
+With [fragments](../new/fragments.html#overview) support, components can potentially have more than one root node. When applied to a multi-root component, a custom directive will be ignored and a warning will be logged.
+:::
+
+## Migration Strategy
+
+[Migration build flag: `CUSTOM_DIR`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/custom-elements-interop.md
+++ b/src/ja/breaking-changes/custom-elements-interop.md
@@ -61,7 +61,7 @@ Vue.config.ignoredElements = ['plastic-button']
 
   It's important to note the runtime config only affects runtime template compilation - it won't affect pre-compiled templates.
 
-## Customized Built-in Elements
+## Customized Built-in Elements {#customized-built-in-elements}
 
 The Custom Elements specification provides a way to use custom elements as [Customized Built-in Element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-customized-builtin-example) by adding the `is` attribute to a built-in element:
 

--- a/src/ja/breaking-changes/custom-elements-interop.md
+++ b/src/ja/breaking-changes/custom-elements-interop.md
@@ -1,0 +1,134 @@
+---
+badges:
+  - breaking
+---
+
+# Custom Elements Interop <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **BREAKING:** The checks to determine whether tags should be treated as custom elements are now performed during template compilation, and should be configured via compiler options instead of runtime config.
+- **BREAKING:** Special `is` attribute usage is restricted to the reserved `<component>` tag only.
+- **NEW:** To support 2.x use cases where `is` was used on native elements to work around native HTML parsing restrictions, prefix the value with `vue:` to resolve it as a Vue component.
+
+## Autonomous Custom Elements
+
+If we want to add a custom element defined outside of Vue (e.g. using the Web Components API), we need to 'instruct' Vue to treat it as a custom element. Let's use the following template as an example.
+
+```html
+<plastic-button></plastic-button>
+```
+
+### 2.x Syntax
+
+In Vue 2.x, configuring tags as custom elements was done via `Vue.config.ignoredElements`:
+
+```js
+// This will make Vue ignore custom element defined outside of Vue
+// (e.g., using the Web Components APIs)
+
+Vue.config.ignoredElements = ['plastic-button']
+```
+
+### 3.x Syntax
+
+**In Vue 3.0, this check is performed during template compilation.** To instruct the compiler to treat `<plastic-button>` as a custom element:
+
+- If using a build step: pass the `isCustomElement` option to the Vue template compiler. If using `vue-loader`, this should be passed via `vue-loader`'s `compilerOptions` option:
+
+  ```js
+  // in webpack config
+  rules: [
+    {
+      test: /\.vue$/,
+      use: 'vue-loader',
+      options: {
+        compilerOptions: {
+          isCustomElement: tag => tag === 'plastic-button'
+        }
+      }
+    }
+    // ...
+  ]
+  ```
+
+- If using on-the-fly template compilation, pass it via `app.config.compilerOptions.isCustomElement`:
+
+  ```js
+  const app = Vue.createApp({})
+  app.config.compilerOptions.isCustomElement = tag => tag === 'plastic-button'
+  ```
+
+  It's important to note the runtime config only affects runtime template compilation - it won't affect pre-compiled templates.
+
+## Customized Built-in Elements
+
+The Custom Elements specification provides a way to use custom elements as [Customized Built-in Element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-customized-builtin-example) by adding the `is` attribute to a built-in element:
+
+```html
+<button is="plastic-button">Click Me!</button>
+```
+
+Vue's usage of the `is` special attribute was simulating what the native attribute does before it was made universally available in browsers. However, in 2.x it was interpreted as rendering a Vue component with the name `plastic-button`. This blocks the native usage of Customized Built-in Element mentioned above.
+
+In 3.0, we are limiting Vue's special treatment of the `is` attribute to the `<component>` tag only.
+
+- When used on the reserved `<component>` tag, it will behave exactly the same as in 2.x;
+- When used on normal components, it will behave like a normal attribute:
+
+  ```html
+  <foo is="bar" />
+  ```
+
+  - 2.x behavior: renders the `bar` component.
+  - 3.x behavior: renders the `foo` component and passing the `is` attribute.
+
+- When used on plain elements, it will be passed to the `createElement` call as the `is` attribute, and also rendered as a native attribute. This supports the usage of customized built-in elements.
+
+  ```html
+  <button is="plastic-button">Click Me!</button>
+  ```
+
+  - 2.x behavior: renders the `plastic-button` component.
+  - 3.x behavior: renders a native button by calling
+
+    ```js
+    document.createElement('button', { is: 'plastic-button' })
+    ```
+
+[Migration build flag: `COMPILER_IS_ON_ELEMENT`](../migration-build.html#compat-configuration)
+
+## `vue:` Prefix for In-DOM Template Parsing Workarounds
+
+> Note: this section only affects cases where Vue templates are directly written in the page's HTML.
+> When using in-DOM templates, the template is subject to native HTML parsing rules. Some HTML elements, such as `<ul>`, `<ol>`, `<table>` and `<select>` have restrictions on what elements can appear inside them, and some elements such as `<li>`, `<tr>`, and `<option>` can only appear inside certain other elements.
+
+### 2.x Syntax
+
+In Vue 2 we recommended working around with these restrictions by using the `is` attribute on a native tag:
+
+```html
+<table>
+  <tr is="blog-post-row"></tr>
+</table>
+```
+
+### 3.x Syntax
+
+With the behavior change of `is`, a `vue:` prefix is now required to resolve the element as a Vue component:
+
+```html
+<table>
+  <tr is="vue:blog-post-row"></tr>
+</table>
+```
+
+## Migration Strategy
+
+- Replace `config.ignoredElements` with either `vue-loader`'s `compilerOptions` (with the build step) or `app.config.compilerOptions.isCustomElement` (with on-the-fly template compilation)
+
+- Change all non-`<component>` tags with `is` usage to `<component is="...">` (for SFC templates) or prefix it with `vue:` (for in-DOM templates).
+
+## See Also
+
+- [Guide - Vue and Web Components](https://vuejs.org/guide/extras/web-components.html)

--- a/src/ja/breaking-changes/custom-elements-interop.md
+++ b/src/ja/breaking-changes/custom-elements-interop.md
@@ -131,4 +131,4 @@ With the behavior change of `is`, a `vue:` prefix is now required to resolve the
 
 ## See Also
 
-- [Guide - Vue and Web Components](https://vuejs.org/guide/extras/web-components.html)
+- [Guide - Vue and Web Components](https://ja.vuejs.org/guide/extras/web-components.html)

--- a/src/ja/breaking-changes/data-option.md
+++ b/src/ja/breaking-changes/data-option.md
@@ -1,0 +1,128 @@
+---
+title: Data Option
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **BREAKING**: `data` component option declaration no longer accepts a plain JavaScript `object` and expects a `function` declaration.
+
+- **BREAKING**: when merging multiple `data` return values from mixins or extends, the merge is now shallow instead of deep (only root-level properties are merged).
+
+## 2.x Syntax
+
+In 2.x, developers could define the `data` option with either an `object` or a `function`.
+
+For example:
+
+```html
+<!-- Object Declaration -->
+<script>
+  const app = new Vue({
+    data: {
+      apiKey: 'a1b2c3'
+    }
+  })
+</script>
+
+<!-- Function Declaration -->
+<script>
+  const app = new Vue({
+    data() {
+      return {
+        apiKey: 'a1b2c3'
+      }
+    }
+  })
+</script>
+```
+
+Though this provided some convenience in terms of root instances having a shared state, this has led to confusion due to the fact that its only possible on the root instance.
+
+## 3.x Update
+
+In 3.x, the `data` option has been standardized to only accept a `function` that returns an `object`.
+
+Using the example above, there would only be one possible implementation of the code:
+
+```html
+<script>
+  import { createApp } from 'vue'
+
+  createApp({
+    data() {
+      return {
+        apiKey: 'a1b2c3'
+      }
+    }
+  }).mount('#app')
+</script>
+```
+
+## Mixin Merge Behavior Change
+
+In addition, when `data()` from a component and its mixins or extends base are merged, the merge is now performed *shallowly*:
+
+```js
+const Mixin = {
+  data() {
+    return {
+      user: {
+        name: 'Jack',
+        id: 1
+      }
+    }
+  }
+}
+
+const CompA = {
+  mixins: [Mixin],
+  data() {
+    return {
+      user: {
+        id: 2
+      }
+    }
+  }
+}
+```
+
+In Vue 2.x, the resulting `$data` is:
+
+```json
+{
+  "user": {
+    "id": 2,
+    "name": "Jack"
+  }
+}
+```
+
+In 3.0, the result will be:
+
+```json
+{
+  "user": {
+    "id": 2
+  }
+}
+```
+
+[Migration build flag: `OPTIONS_DATA_FN`](../migration-build.html#compat-configuration)
+
+## Migration Strategy
+
+For users relying on the object declaration, we recommend:
+
+- Extracting the shared data into an external object and using it as a property in `data`
+- Rewrite references to the shared data to point to a new shared object
+
+For users relying on the deep merge behavior from mixins, we recommend refactoring your code to avoid such reliance altogether, since deep merges from mixins are very implicit and can make the code logic more difficult to understand and debug.
+
+[Migration build flags:](../migration-build.html#compat-configuration)
+
+- `OPTIONS_DATA_FN`
+- `OPTIONS_DATA_MERGE`

--- a/src/ja/breaking-changes/data-option.md
+++ b/src/ja/breaking-changes/data-option.md
@@ -62,7 +62,7 @@ Using the example above, there would only be one possible implementation of the 
 </script>
 ```
 
-## Mixin Merge Behavior Change
+## Mixin Merge Behavior Change {#mixin-merge-behavior-change}
 
 In addition, when `data()` from a component and its mixins or extends base are merged, the merge is now performed *shallowly*:
 

--- a/src/ja/breaking-changes/emits-option.md
+++ b/src/ja/breaking-changes/emits-option.md
@@ -1,0 +1,97 @@
+---
+title: emits Option
+badges:
+  - new
+---
+
+# `emits` Option <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Vue 3 now offers an `emits` option, similar to the existing `props` option. This option can be used to define the events that a component can emit to its parent.
+
+## 2.x Behavior
+
+In Vue 2, you can define the props that a component receives, but you can't declare which events it can emit:
+
+```vue
+<template>
+  <div>
+    <p>{{ text }}</p>
+    <button v-on:click="$emit('accepted')">OK</button>
+  </div>
+</template>
+<script>
+  export default {
+    props: ['text']
+  }
+</script>
+```
+
+## 3.x Behavior
+
+Similar to props, the events that the component emits can now be defined with the `emits` option:
+
+```vue
+<template>
+  <div>
+    <p>{{ text }}</p>
+    <button v-on:click="$emit('accepted')">OK</button>
+  </div>
+</template>
+<script>
+  export default {
+    props: ['text'],
+    emits: ['accepted']
+  }
+</script>
+```
+
+The option also accepts an object, which allows the developer to define validators for the arguments that are passed with the emitted event, similar to validators in `props` definitions.
+
+For more information on this, please read the [API documentation for this feature](https://vuejs.org/api/options-state.html#emits).
+
+## Migration Strategy
+
+It is highly recommended that you document all the events emitted by each of your components using `emits`.
+
+This is especially important because of [the removal of the `.native` modifier](./v-on-native-modifier-removed.md). Any listeners for events that aren't declared with `emits` will now be included in the component's `$attrs`, which by default will be bound to the component's root node.
+
+### Example
+
+For components that re-emit native events to their parent, this would now lead to two events being fired:
+
+```vue
+<template>
+  <button v-on:click="$emit('click', $event)">OK</button>
+</template>
+<script>
+export default {
+  emits: [] // without declared event
+}
+</script>
+```
+
+When a parent listens for the `click` event on the component:
+
+```html
+<my-button v-on:click="handleClick"></my-button>
+```
+
+it would now be triggered _twice_:
+
+- Once from `$emit()`.
+- Once from a native event listener applied to the root element.
+
+Here you have two options:
+
+1. Properly declare the `click` event. This is useful if you actually do add some logic to that event handler in `<my-button>`.
+2. Remove the re-emitting of the event, since the parent can now listen for the native event easily, without adding `.native`. Suitable when you really only re-emit the event anyway.
+
+## See also
+
+- [Relevant RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0030-emits-option.md)
+- [Migration guide - `.native` modifier removed](./v-on-native-modifier-removed.md)
+- [Migration guide - `$listeners` removed](./listeners-removed.md)
+- [Migration guide - `$attrs` includes `class` & `style`](./attrs-includes-class-style.md)
+- [Migration guide - Changes in the Render Functions API](./render-function-api.md)

--- a/src/ja/breaking-changes/emits-option.md
+++ b/src/ja/breaking-changes/emits-option.md
@@ -49,7 +49,7 @@ Similar to props, the events that the component emits can now be defined with th
 
 The option also accepts an object, which allows the developer to define validators for the arguments that are passed with the emitted event, similar to validators in `props` definitions.
 
-For more information on this, please read the [API documentation for this feature](https://vuejs.org/api/options-state.html#emits).
+For more information on this, please read the [API documentation for this feature](https://ja.vuejs.org/api/options-state.html#emits).
 
 ## Migration Strategy
 

--- a/src/ja/breaking-changes/events-api.md
+++ b/src/ja/breaking-changes/events-api.md
@@ -1,0 +1,104 @@
+---
+badges:
+  - breaking
+---
+
+# Events API <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+`$on`, `$off` and `$once` instance methods are removed. Component instances no longer implement the event emitter interface.
+
+## 2.x Syntax
+
+In 2.x, a Vue instance could be used to trigger handlers attached imperatively via the event emitter API (`$on`, `$off` and `$once`). This could be used to create an _event bus_ to create global event listeners used across the whole application:
+
+```js
+// eventBus.js
+
+const eventBus = new Vue()
+
+export default eventBus
+```
+
+```js
+// ChildComponent.vue
+import eventBus from './eventBus'
+
+export default {
+  mounted() {
+    // adding eventBus listener
+    eventBus.$on('custom-event', () => {
+      console.log('Custom event triggered!')
+    })
+  },
+  beforeDestroy() {
+    // removing eventBus listener
+    eventBus.$off('custom-event')
+  }
+}
+```
+
+```js
+// ParentComponent.vue
+import eventBus from './eventBus'
+
+export default {
+  methods: {
+    callGlobalCustomEvent() {
+      eventBus.$emit('custom-event') // if ChildComponent is mounted, we will have a message in the console
+    }
+  }
+}
+```
+
+## 3.x Update
+
+We removed `$on`, `$off` and `$once` methods from the instance completely. `$emit` is still a part of the existing API as it's used to trigger event handlers declaratively attached by a parent component.
+
+## Migration Strategy
+
+[Migration build flag: `INSTANCE_EVENT_EMITTER`](../migration-build.html#compat-configuration)
+
+In Vue 3, it is no longer possible to use these APIs to listen to a component's own emitted events from within a component. There is no migration path for that use case.
+
+### Root Component Events
+
+Static event listeners can be added to the root component by passing them as props to `createApp`:
+
+```js
+createApp(App, {
+  // Listen for the 'expand' event
+  onExpand() {
+    console.log('expand')
+  }
+})
+```
+
+### Event Bus
+
+The event bus pattern can be replaced by using an external library implementing the event emitter interface, for example [mitt](https://github.com/developit/mitt) or [tiny-emitter](https://github.com/scottcorgan/tiny-emitter).
+
+Example:
+
+```js
+// eventBus.js
+import emitter from 'tiny-emitter/instance'
+
+export default {
+  $on: (...args) => emitter.on(...args),
+  $once: (...args) => emitter.once(...args),
+  $off: (...args) => emitter.off(...args),
+  $emit: (...args) => emitter.emit(...args)
+}
+```
+
+This provides the same event emitter API as in Vue 2.
+
+In most circumstances, using a global event bus for communicating between components is discouraged. While it is often the simplest solution in the short term, it almost invariably proves to be a maintenance headache in the long term. Depending on the circumstances, there are various alternatives to using an event bus:
+
+* Props and events should be your first choice for parent-child communication. Siblings can communicate via their parent.
+* Provide / inject allow a component to communicate with its slot contents. This is useful for tightly-coupled components that are always used together.
+* Provide / inject can also be used for long-distance communication between components. It can help to avoid 'prop drilling', where props need to be passed down through many levels of components that don't need those props themselves.
+* Prop drilling can also be avoided by refactoring to use slots. If an interim component doesn't need the props then it might indicate a problem with separation of concerns. Introducing a slot in that component allows the parent to create the content directly, so that props can be passed without the interim component needing to get involved.
+* [Global state management](https://vuejs.org/guide/scaling-up/state-management.html), such as [Pinia](https://pinia.vuejs.org/).

--- a/src/ja/breaking-changes/events-api.md
+++ b/src/ja/breaking-changes/events-api.md
@@ -101,4 +101,4 @@ In most circumstances, using a global event bus for communicating between compon
 * Provide / inject allow a component to communicate with its slot contents. This is useful for tightly-coupled components that are always used together.
 * Provide / inject can also be used for long-distance communication between components. It can help to avoid 'prop drilling', where props need to be passed down through many levels of components that don't need those props themselves.
 * Prop drilling can also be avoided by refactoring to use slots. If an interim component doesn't need the props then it might indicate a problem with separation of concerns. Introducing a slot in that component allows the parent to create the content directly, so that props can be passed without the interim component needing to get involved.
-* [Global state management](https://vuejs.org/guide/scaling-up/state-management.html), such as [Pinia](https://pinia.vuejs.org/).
+* [Global state management](https://ja.vuejs.org/guide/scaling-up/state-management.html), such as [Pinia](https://pinia.vuejs.org/).

--- a/src/ja/breaking-changes/filters.md
+++ b/src/ja/breaking-changes/filters.md
@@ -1,0 +1,107 @@
+---
+badges:
+  - removed
+---
+
+# Filters <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Filters are removed from Vue 3.0 and no longer supported.
+
+## 2.x Syntax
+
+In 2.x, developers could use filters in order to apply common text formatting.
+
+For example:
+
+```html
+<template>
+  <h1>Bank Account Balance</h1>
+  <p>{{ accountBalance | currencyUSD }}</p>
+</template>
+
+<script>
+  export default {
+    props: {
+      accountBalance: {
+        type: Number,
+        required: true
+      }
+    },
+    filters: {
+      currencyUSD(value) {
+        return '$' + value
+      }
+    }
+  }
+</script>
+```
+
+While this seems like a convenience, it requires a custom syntax that breaks the assumption of expressions inside curly braces being "just JavaScript," which has both learning and implementation costs.
+
+## 3.x Update
+
+In 3.x, filters are removed and no longer supported. Instead, we recommend replacing them with method calls or computed properties.
+
+Using the example above, here is one example of how it could be implemented.
+
+```html
+<template>
+  <h1>Bank Account Balance</h1>
+  <p>{{ accountInUSD }}</p>
+</template>
+
+<script>
+  export default {
+    props: {
+      accountBalance: {
+        type: Number,
+        required: true
+      }
+    },
+    computed: {
+      accountInUSD() {
+        return '$' + this.accountBalance
+      }
+    }
+  }
+</script>
+```
+
+## Migration Strategy
+
+Instead of using filters, we recommend replacing them with computed properties or methods.
+
+[Migration build flags:](../migration-build.html#compat-configuration)
+
+- `FILTERS`
+- `COMPILER_FILTERS`
+
+### Global Filters
+
+If you are using filters that were globally registered and then used throughout your app, it's likely not convenient to replace them with computed properties or methods in each individual component.
+
+Instead, you can make your global filters available to all components through [globalProperties](https://vuejs.org/api/application.html#app-config-globalproperties):
+
+```js
+// main.js
+const app = createApp(App)
+
+app.config.globalProperties.$filters = {
+  currencyUSD(value) {
+    return '$' + value
+  }
+}
+```
+
+Then you can fix all templates using this `$filters` object like this:
+
+```html
+<template>
+  <h1>Bank Account Balance</h1>
+  <p>{{ $filters.currencyUSD(accountBalance) }}</p>
+</template>
+```
+
+Note that with this approach, you can only use methods, not computed properties, as the latter only make sense when defined in the context of an individual component.

--- a/src/ja/breaking-changes/filters.md
+++ b/src/ja/breaking-changes/filters.md
@@ -82,7 +82,7 @@ Instead of using filters, we recommend replacing them with computed properties o
 
 If you are using filters that were globally registered and then used throughout your app, it's likely not convenient to replace them with computed properties or methods in each individual component.
 
-Instead, you can make your global filters available to all components through [globalProperties](https://vuejs.org/api/application.html#app-config-globalproperties):
+Instead, you can make your global filters available to all components through [globalProperties](https://ja.vuejs.org/api/application.html#app-config-globalproperties):
 
 ```js
 // main.js

--- a/src/ja/breaking-changes/functional-components.md
+++ b/src/ja/breaking-changes/functional-components.md
@@ -1,0 +1,120 @@
+---
+badges:
+  - breaking
+---
+
+# Functional Components <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+In terms of what has changed, at a high level:
+
+- Performance gains from 2.x for functional components are now negligible in 3.x, so we recommend just using stateful components
+- Functional components can only be created using a plain function that receives `props` and `context` (i.e., `slots`, `attrs`, `emit`)
+- **BREAKING:** `functional` attribute on single-file component (SFC) `<template>` is removed
+- **BREAKING:** `{ functional: true }` option in components created by functions is removed
+
+For more information, read on!
+
+## Introduction
+
+In Vue 2, functional components had two primary use cases:
+
+- as a performance optimization, because they initialized much faster than stateful components
+- to return multiple root nodes
+
+However, in Vue 3, the performance of stateful components has improved to the point that the difference is negligible. In addition, stateful components now also include the ability to return multiple root nodes.
+
+As a result, the only remaining use case for functional components is simple components, such as a component to create a dynamic heading. Otherwise, it is recommended to use stateful components as you normally would.
+
+## 2.x Syntax
+
+Using the `<dynamic-heading>` component, which is responsible for rendering out the appropriate heading (i.e., `h1`, `h2`, `h3`, etc.), this could have been written as a single-file component in 2.x as:
+
+```js
+// Vue 2 Functional Component Example
+export default {
+  functional: true,
+  props: ['level'],
+  render(h, { props, data, children }) {
+    return h(`h${props.level}`, data, children)
+  }
+}
+```
+
+Or, for those who preferred the `<template>` in a single-file component:
+
+```vue
+<!-- Vue 2 Functional Component Example with <template> -->
+<template functional>
+  <component
+    :is="`h${props.level}`"
+    v-bind="attrs"
+    v-on="listeners"
+  />
+</template>
+
+<script>
+export default {
+  props: ['level']
+}
+</script>
+```
+
+## 3.x Syntax
+
+### Components Created by Functions
+
+Now in Vue 3, all functional components are created with a plain function. In other words, there is no need to define the `{ functional: true }` component option.
+
+They will receive two arguments: `props` and `context`. The `context` argument is an object that contains a component's `attrs`, `slots`, and `emit` properties.
+
+In addition, rather than implicitly provide `h` in a `render` function, `h` is now imported globally.
+
+Using the previously mentioned example of a `<dynamic-heading>` component, here is how it looks now.
+
+```js
+import { h } from 'vue'
+
+const DynamicHeading = (props, context) => {
+  return h(`h${props.level}`, context.attrs, context.slots)
+}
+
+DynamicHeading.props = ['level']
+
+export default DynamicHeading
+```
+
+### Single File Components (SFCs)
+
+In 3.x, the performance difference between stateful and functional components has been drastically reduced and will be insignificant in most use cases. As a result, the migration path for developers using `functional` on SFCs is to remove the attribute and rename all references of `props` to `$props` and `attrs` to `$attrs`.
+
+Using our `<dynamic-heading>` example from before, here is how it would look now.
+
+```vue{1,3,4}
+<template>
+  <component
+    v-bind:is="`h${$props.level}`"
+    v-bind="$attrs"
+  />
+</template>
+
+<script>
+export default {
+  props: ['level']
+}
+</script>
+```
+
+The main differences are that:
+
+1. `functional` attribute removed on `<template>`
+1. `listeners` are now passed as part of `$attrs` and can be removed
+
+## Next Steps
+
+For more information on the usage of the new functional components and the changes to render functions in general, see:
+
+- [Migration: Render Functions](./render-function-api.html)
+- [Guide: Render Functions](https://vuejs.org/guide/extras/render-function.html#render-functions-jsx)
+- [Migration build flag: `COMPONENT_FUNCTIONAL`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/functional-components.md
+++ b/src/ja/breaking-changes/functional-components.md
@@ -85,7 +85,7 @@ DynamicHeading.props = ['level']
 export default DynamicHeading
 ```
 
-### Single File Components (SFCs)
+### Single File Components (SFCs) {#single-file-components-sfcs}
 
 In 3.x, the performance difference between stateful and functional components has been drastically reduced and will be insignificant in most use cases. As a result, the migration path for developers using `functional` on SFCs is to remove the attribute and rename all references of `props` to `$props` and `attrs` to `$attrs`.
 

--- a/src/ja/breaking-changes/functional-components.md
+++ b/src/ja/breaking-changes/functional-components.md
@@ -116,5 +116,5 @@ The main differences are that:
 For more information on the usage of the new functional components and the changes to render functions in general, see:
 
 - [Migration: Render Functions](./render-function-api.html)
-- [Guide: Render Functions](https://vuejs.org/guide/extras/render-function.html#render-functions-jsx)
+- [Guide: Render Functions](https://ja.vuejs.org/guide/extras/render-function.html#render-functions-jsx)
 - [Migration build flag: `COMPONENT_FUNCTIONAL`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/global-api-treeshaking.md
+++ b/src/ja/breaking-changes/global-api-treeshaking.md
@@ -1,0 +1,166 @@
+---
+badges:
+  - breaking
+---
+
+# Global API Treeshaking <MigrationBadges :badges="$frontmatter.badges" />
+
+## 2.x Syntax
+
+If you’ve ever had to manually manipulate DOM in Vue, you might have come across this pattern:
+
+```js
+import Vue from 'vue'
+
+Vue.nextTick(() => {
+  // something DOM-related
+})
+```
+
+Or, if you’ve been unit-testing an application involving async components, chances are you’ve written something like this:
+
+```js
+import { shallowMount } from '@vue/test-utils'
+import { MyComponent } from './MyComponent.vue'
+
+test('an async feature', async () => {
+  const wrapper = shallowMount(MyComponent)
+
+  // execute some DOM-related tasks
+
+  await wrapper.vm.$nextTick()
+
+  // run your assertions
+})
+```
+
+`Vue.nextTick()` is a global API exposed directly on a single Vue object – in fact, the instance method `$nextTick()` is just a handy wrapper around `Vue.nextTick()` with the callback’s `this` context automatically bound to the current instance for convenience.
+
+But what if you’ve never had to deal with manual DOM manipulation, nor are you using or testing async components in your app? Or, what if, for whatever reason, you prefer to use the good old `window.setTimeout()` instead? In such a case, the code for `nextTick()` will become dead code – that is, code that’s written but never used. And dead code is hardly a good thing, especially in our client-side context where every kilobyte matters.
+
+Module bundlers like webpack and Rollup (which Vite is based upon) support [tree-shaking](https://webpack.js.org/guides/tree-shaking/), which is a fancy term for “dead code elimination.” Unfortunately, due to how the code is written in previous Vue versions, global APIs like `Vue.nextTick()` are not tree-shakeable and will be included in the final bundle regardless of where they are actually used or not.
+
+## 3.x Syntax
+
+In Vue 3, the global and internal APIs have been restructured with tree-shaking support in mind. As a result, the global APIs can now only be accessed as named exports for the ES Modules build. For example, our previous snippets should now look like this:
+
+```js
+import { nextTick } from 'vue'
+
+nextTick(() => {
+  // something DOM-related
+})
+```
+
+and
+
+```js
+import { shallowMount } from '@vue/test-utils'
+import { MyComponent } from './MyComponent.vue'
+import { nextTick } from 'vue'
+
+test('an async feature', async () => {
+  const wrapper = shallowMount(MyComponent)
+
+  // execute some DOM-related tasks
+
+  await nextTick()
+
+  // run your assertions
+})
+```
+
+Calling `Vue.nextTick()` directly will now result in the infamous `undefined is not a function` error.
+
+With this change, provided the module bundler supports tree-shaking, global APIs that are not used in a Vue application will be eliminated from the final bundle, resulting in an optimal file size.
+
+## Affected APIs
+
+These global APIs in Vue 2.x are affected by this change:
+
+- `Vue.nextTick`
+- `Vue.observable` (replaced by `Vue.reactive`)
+- `Vue.version`
+- `Vue.compile` (only in full builds)
+- `Vue.set` (only in compat builds)
+- `Vue.delete` (only in compat builds)
+
+## Internal Helpers
+
+In addition to public APIs, many of the internal components/helpers are now exported as named exports as well. This allows the compiler to output code that only imports features when they are used. For example the following template:
+
+```html
+<transition>
+  <div v-show="ok">hello</div>
+</transition>
+```
+
+is compiled into something similar to the following:
+
+```js
+import { h, Transition, withDirectives, vShow } from 'vue'
+
+export function render() {
+  return h(Transition, [withDirectives(h('div', 'hello'), [[vShow, this.ok]])])
+}
+```
+
+This essentially means the `Transition` component only gets imported when the application actually makes use of it. In other words, if the application doesn’t have any `<transition>` component, the code supporting this feature will not be present in the final bundle.
+
+With global tree-shaking, the users only “pay” for the features they actually use. Even better, knowing that optional features won't increase the bundle size for applications not using them, framework size has become much less a concern for additional core features in the future, if at all.
+
+::: warning Important
+The above only applies to the [ES Modules builds](https://github.com/vuejs/core/tree/master/packages/vue#which-dist-file-to-use) for use with tree-shaking capable bundlers - the UMD build still includes all features and exposes everything on the Vue global variable (and the compiler will produce appropriate output to use APIs off the global instead of importing).
+:::
+
+## Usage in Plugins
+
+If your plugin relies on an affected Vue 2.x global API, for instance:
+
+```js
+const plugin = {
+  install: Vue => {
+    Vue.nextTick(() => {
+      // ...
+    })
+  }
+}
+```
+
+In Vue 3, you’ll have to import it explicitly:
+
+```js
+import { nextTick } from 'vue'
+
+const plugin = {
+  install: app => {
+    nextTick(() => {
+      // ...
+    })
+  }
+}
+```
+
+If you use a module bundle like webpack, this may cause Vue’s source code to be bundled into the plugin, and more often than not that’s not what you'd expect. A common practice to prevent this from happening is to configure the module bundler to exclude Vue from the final bundle. In webpack's case, you can use the [`externals`](https://webpack.js.org/configuration/externals/) configuration option:
+
+```js
+// webpack.config.js
+module.exports = {
+  /*...*/
+  externals: {
+    vue: 'Vue'
+  }
+}
+```
+
+This will tell webpack to treat the Vue module as an external library and not bundle it.
+
+If your module bundler of choice happens to be [Rollup](https://rollupjs.org/), you basically get the same effect for free, as by default Rollup will treat absolute module IDs (`'vue'` in our case) as external dependencies and not include them in the final bundle. During bundling though, it might emit a [“Treating vue as external dependency”](https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency) warning, which can be suppressed with the `external` option:
+
+```js
+// rollup.config.js
+export default {
+  /*...*/
+  external: ['vue']
+}
+```

--- a/src/ja/breaking-changes/global-api.md
+++ b/src/ja/breaking-changes/global-api.md
@@ -1,0 +1,290 @@
+---
+badges:
+  - breaking
+---
+
+# Global API Application Instance<MigrationBadges :badges="$frontmatter.badges" />
+
+Vue 2.x has a number of global APIs and configurations that globally mutate Vue’s behavior. For instance, to register a global component, you would use the `Vue.component` API like this:
+
+```js
+Vue.component('button-counter', {
+  data: () => ({
+    count: 0
+  }),
+  template: '<button @click="count++">Clicked {{ count }} times.</button>'
+})
+```
+
+Similarly, this is how a global directive is declared:
+
+```js
+Vue.directive('focus', {
+  inserted: (el) => el.focus()
+})
+```
+
+While this approach is convenient, it leads to a couple of problems. Technically, Vue 2 doesn't have a concept of an "app". What we define as an app is simply a root Vue instance created via `new Vue()`. Every root instance created from the same Vue constructor **shares the same global configuration**. As a result:
+
+- Global configuration makes it easy to accidentally pollute other test cases during testing. Users need to carefully store original global configuration and restore it after each test (e.g. resetting `Vue.config.errorHandler`). Some APIs like `Vue.use` and `Vue.mixin` don't even have a way to revert their effects. This makes tests involving plugins particularly tricky. In fact, vue-test-utils has to implement a special API `createLocalVue` to deal with this:
+
+  ```js
+  import { createLocalVue, mount } from '@vue/test-utils'
+
+  // create an extended `Vue` constructor
+  const localVue = createLocalVue()
+
+  // install a plugin “globally” on the “local” Vue constructor
+  localVue.use(MyPlugin)
+
+  // pass the `localVue` to the mount options
+  mount(Component, { localVue })
+  ```
+
+- Global configuration makes it difficult to share the same copy of Vue between multiple "apps" on the same page, but with different global configurations.
+
+  ```js
+  // this affects both root instances
+  Vue.mixin({
+    /* ... */
+  })
+
+  const app1 = new Vue({ el: '#app-1' })
+  const app2 = new Vue({ el: '#app-2' })
+  ```
+
+To avoid these problems, in Vue 3 we introduce…
+
+## A New Global API: `createApp`
+
+Calling `createApp` returns an _app instance_, a new concept in Vue 3.
+
+```js
+import { createApp } from 'vue'
+
+const app = createApp({})
+```
+
+If you're using a CDN build of Vue then `createApp` is exposed via the global `Vue` object:
+
+```js
+const { createApp } = Vue
+
+const app = createApp({})
+```
+
+An app instance exposes a subset of the Vue 2 global APIs. The rule of thumb is _any APIs that globally mutate Vue's behavior are now moved to the app instance_. Here is a table of the Vue 2 global APIs and their corresponding instance APIs:
+
+| 2.x Global API             | 3.x Instance API (`app`)                                                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Vue.config                 | app.config                                                                                                                      |
+| Vue.config.productionTip   | _removed_ ([see below](#config-productiontip-removed))                                                                          |
+| Vue.config.ignoredElements | app.config.compilerOptions.isCustomElement ([see below](#config-ignoredelements-is-now-config-compileroptions-iscustomelement)) |
+| Vue.component              | app.component                                                                                                                   |
+| Vue.directive              | app.directive                                                                                                                   |
+| Vue.mixin                  | app.mixin                                                                                                                       |
+| Vue.use                    | app.use ([see below](#a-note-for-plugin-authors))                                                                               |
+| Vue.prototype              | app.config.globalProperties ([see below](#vue-prototype-replaced-by-config-globalproperties))                                   |
+| Vue.extend                 | _removed_ ([see below](#vue-extend-removed))                                                                                    |
+
+All other global APIs that do not globally mutate behavior are now named exports, as documented in [Global API Treeshaking](./global-api-treeshaking.html).
+
+### `config.productionTip` Removed
+
+In Vue 3.x, the "use production build" tip will only show up when using the "dev + full build" (the build that includes the runtime compiler and has warnings).
+
+For ES modules builds, since they are used with bundlers, and in most cases a CLI or boilerplate would have configured the production env properly, this tip will no longer show up.
+
+[Migration build flag: `CONFIG_PRODUCTION_TIP`](../migration-build.html#compat-configuration)
+
+### `config.ignoredElements` Is Now `config.compilerOptions.isCustomElement`
+
+This config option was introduced with the intention to support native custom elements, so the renaming better conveys what it does. The new option also expects a function which provides more flexibility than the old string / RegExp approach:
+
+```js
+// before
+Vue.config.ignoredElements = ['my-el', /^ion-/]
+
+// after
+const app = createApp({})
+app.config.compilerOptions.isCustomElement = (tag) => tag.startsWith('ion-')
+```
+
+::: tip Important
+
+In Vue 3, the check of whether an element is a component or not has been moved to the template compilation phase, therefore this config option is only respected when using the runtime compiler. If you are using the runtime-only build, `isCustomElement` must be passed to `@vue/compiler-dom` in the build setup instead - for example, via the [`compilerOptions` option in vue-loader](https://vue-loader.vuejs.org/options.html#compileroptions).
+
+- If `config.compilerOptions.isCustomElement` is assigned to when using a runtime-only build, a warning will be emitted instructing the user to pass the option in the build setup instead;
+- This will be a new top-level option in the Vue CLI config.
+  :::
+
+[Migration build flag: `CONFIG_IGNORED_ELEMENTS`](../migration-build.html#compat-configuration)
+
+### `Vue.prototype` Replaced by `config.globalProperties`
+
+In Vue 2, `Vue.prototype` was commonly used to add properties that would be accessible in all components.
+
+The equivalent in Vue 3 is [`config.globalProperties`](https://vuejs.org/api/application.html#app-config-globalproperties). These properties will be copied across as part of instantiating a component within the application:
+
+```js
+// before - Vue 2
+Vue.prototype.$http = () => {}
+```
+
+```js
+// after - Vue 3
+const app = createApp({})
+app.config.globalProperties.$http = () => {}
+```
+
+Using `provide` (discussed [below](#provide-inject)) should also be considered as an alternative to `globalProperties`.
+
+[Migration build flag: `GLOBAL_PROTOTYPE`](../migration-build.html#compat-configuration)
+
+### `Vue.extend` Removed
+
+In Vue 2.x, `Vue.extend` was used to create a "subclass" of the base Vue constructor with the argument that should be an object containing component options. In Vue 3.x, we don't have the concept of component constructors anymore. Mounting a component should always use the `createApp` global API:
+
+```js
+// before - Vue 2
+
+// create constructor
+const Profile = Vue.extend({
+  template: '<p>{{firstName}} {{lastName}} aka {{alias}}</p>',
+  data() {
+    return {
+      firstName: 'Walter',
+      lastName: 'White',
+      alias: 'Heisenberg'
+    }
+  }
+})
+// create an instance of Profile and mount it on an element
+new Profile().$mount('#mount-point')
+```
+
+```js
+// after - Vue 3
+const Profile = {
+  template: '<p>{{firstName}} {{lastName}} aka {{alias}}</p>',
+  data() {
+    return {
+      firstName: 'Walter',
+      lastName: 'White',
+      alias: 'Heisenberg'
+    }
+  }
+}
+
+Vue.createApp(Profile).mount('#mount-point')
+```
+
+#### Type Inference
+
+In Vue 2, `Vue.extend` was also used for providing TypeScript type inference for the component options. In Vue 3, the `defineComponent` global API can be used in place of `Vue.extend` for the same purpose.
+
+Note that although the return type of `defineComponent` is a constructor-like type, it is only used for TSX inference. At runtime `defineComponent` is largely a noop and will return the options object as-is.
+
+#### Component Inheritance
+
+In Vue 3, we strongly recommend favoring composition via [Composition API](https://vuejs.org/guide/reusability/composables.html) over inheritance and mixins. If for some reason you still need component inheritance, you can use the [`extends` option](https://vuejs.org/api/options-composition.html#extends) instead of `Vue.extend`.
+
+[Migration build flag: `GLOBAL_EXTEND`](../migration-build.html#compat-configuration)
+
+### A Note for Plugin Authors
+
+It is a common practice for plugin authors to install the plugins automatically in their UMD builds using `Vue.use`. For instance, this is how the official `vue-router` plugin installs itself in a browser environment:
+
+```js
+var inBrowser = typeof window !== 'undefined'
+/* … */
+if (inBrowser && window.Vue) {
+  window.Vue.use(VueRouter)
+}
+```
+
+As the `use` global API is no longer available in Vue 3, this method will cease to work and calling `Vue.use()` will now trigger a warning. Instead, the end-user will now have to explicitly specify using the plugin on the app instance:
+
+```js
+const app = createApp(MyApp)
+app.use(VueRouter)
+```
+
+## Mounting App Instance
+
+After being initialized with `createApp(/* options */)`, the app instance `app` can be used to mount a root component instance with `app.mount(domTarget)`:
+
+```js
+import { createApp } from 'vue'
+import MyApp from './MyApp.vue'
+
+const app = createApp(MyApp)
+app.mount('#app')
+```
+
+With all these changes, the component and directive we have at the beginning of the guide will be rewritten into something like this:
+
+```js
+const app = createApp(MyApp)
+
+app.component('button-counter', {
+  data: () => ({
+    count: 0
+  }),
+  template: '<button @click="count++">Clicked {{ count }} times.</button>'
+})
+
+app.directive('focus', {
+  mounted: (el) => el.focus()
+})
+
+// now every application instance mounted with app.mount(), along with its
+// component tree, will have the same “button-counter” component
+// and “focus” directive without polluting the global environment
+app.mount('#app')
+```
+
+[Migration build flag: `GLOBAL_MOUNT`](../migration-build.html#compat-configuration)
+
+## Provide / Inject
+
+Similar to using the `provide` option in a 2.x root instance, a Vue 3 app instance can also provide dependencies that can be injected by any component inside the app:
+
+```js
+// in the entry
+app.provide('guide', 'Vue 3 Guide')
+
+// in a child component
+export default {
+  inject: {
+    book: {
+      from: 'guide'
+    }
+  },
+  template: `<div>{{ book }}</div>`
+}
+```
+
+Using `provide` is especially useful when writing a plugin, as an alternative to `globalProperties`.
+
+## Share Configurations Among Apps
+
+One way to share configurations e.g. components or directives among apps is to create a factory function, like this:
+
+```js
+import { createApp } from 'vue'
+import Foo from './Foo.vue'
+import Bar from './Bar.vue'
+
+const createMyApp = (options) => {
+  const app = createApp(options)
+  app.directive('focus' /* ... */)
+
+  return app
+}
+
+createMyApp(Foo).mount('#foo')
+createMyApp(Bar).mount('#bar')
+```
+
+Now the `focus` directive will be available in both `Foo` and `Bar` instances and their descendants.

--- a/src/ja/breaking-changes/global-api.md
+++ b/src/ja/breaking-changes/global-api.md
@@ -55,7 +55,7 @@ While this approach is convenient, it leads to a couple of problems. Technically
 
 To avoid these problems, in Vue 3 we introduce…
 
-## A New Global API: `createApp`
+## A New Global API: `createApp` {#a-new-global-api-createapp}
 
 Calling `createApp` returns an _app instance_, a new concept in Vue 3.
 
@@ -89,7 +89,7 @@ An app instance exposes a subset of the Vue 2 global APIs. The rule of thumb is 
 
 All other global APIs that do not globally mutate behavior are now named exports, as documented in [Global API Treeshaking](./global-api-treeshaking.html).
 
-### `config.productionTip` Removed
+### `config.productionTip` Removed {#config-productiontip-removed}
 
 In Vue 3.x, the "use production build" tip will only show up when using the "dev + full build" (the build that includes the runtime compiler and has warnings).
 
@@ -97,7 +97,7 @@ For ES modules builds, since they are used with bundlers, and in most cases a CL
 
 [Migration build flag: `CONFIG_PRODUCTION_TIP`](../migration-build.html#compat-configuration)
 
-### `config.ignoredElements` Is Now `config.compilerOptions.isCustomElement`
+### `config.ignoredElements` Is Now `config.compilerOptions.isCustomElement` {#config-ignoredelements-is-now-config-compileroptions-iscustomelement}
 
 This config option was introduced with the intention to support native custom elements, so the renaming better conveys what it does. The new option also expects a function which provides more flexibility than the old string / RegExp approach:
 
@@ -120,7 +120,7 @@ In Vue 3, the check of whether an element is a component or not has been moved t
 
 [Migration build flag: `CONFIG_IGNORED_ELEMENTS`](../migration-build.html#compat-configuration)
 
-### `Vue.prototype` Replaced by `config.globalProperties`
+### `Vue.prototype` Replaced by `config.globalProperties` {#vue-prototype-replaced-by-config-globalproperties}
 
 In Vue 2, `Vue.prototype` was commonly used to add properties that would be accessible in all components.
 
@@ -141,7 +141,7 @@ Using `provide` (discussed [below](#provide-inject)) should also be considered a
 
 [Migration build flag: `GLOBAL_PROTOTYPE`](../migration-build.html#compat-configuration)
 
-### `Vue.extend` Removed
+### `Vue.extend` Removed {#vue-extend-removed}
 
 In Vue 2.x, `Vue.extend` was used to create a "subclass" of the base Vue constructor with the argument that should be an object containing component options. In Vue 3.x, we don't have the concept of component constructors anymore. Mounting a component should always use the `createApp` global API:
 
@@ -210,7 +210,7 @@ const app = createApp(MyApp)
 app.use(VueRouter)
 ```
 
-## Mounting App Instance
+## Mounting App Instance {#mounting-app-instance}
 
 After being initialized with `createApp(/* options */)`, the app instance `app` can be used to mount a root component instance with `app.mount(domTarget)`:
 

--- a/src/ja/breaking-changes/global-api.md
+++ b/src/ja/breaking-changes/global-api.md
@@ -124,7 +124,7 @@ In Vue 3, the check of whether an element is a component or not has been moved t
 
 In Vue 2, `Vue.prototype` was commonly used to add properties that would be accessible in all components.
 
-The equivalent in Vue 3 is [`config.globalProperties`](https://vuejs.org/api/application.html#app-config-globalproperties). These properties will be copied across as part of instantiating a component within the application:
+The equivalent in Vue 3 is [`config.globalProperties`](https://ja.vuejs.org/api/application.html#app-config-globalproperties). These properties will be copied across as part of instantiating a component within the application:
 
 ```js
 // before - Vue 2
@@ -187,7 +187,7 @@ Note that although the return type of `defineComponent` is a constructor-like ty
 
 #### Component Inheritance
 
-In Vue 3, we strongly recommend favoring composition via [Composition API](https://vuejs.org/guide/reusability/composables.html) over inheritance and mixins. If for some reason you still need component inheritance, you can use the [`extends` option](https://vuejs.org/api/options-composition.html#extends) instead of `Vue.extend`.
+In Vue 3, we strongly recommend favoring composition via [Composition API](https://ja.vuejs.org/guide/reusability/composables.html) over inheritance and mixins. If for some reason you still need component inheritance, you can use the [`extends` option](https://ja.vuejs.org/api/options-composition.html#extends) instead of `Vue.extend`.
 
 [Migration build flag: `GLOBAL_EXTEND`](../migration-build.html#compat-configuration)
 

--- a/src/ja/breaking-changes/index.md
+++ b/src/ja/breaking-changes/index.md
@@ -1,66 +1,66 @@
-# Breaking Changes
+# 破壊的変更
 
-This page lists all Vue 3 breaking changes from Vue 2.
+このページでは、Vue 2 から Vue 3 の破壊的変更をすべてリストアップしています。
 
-While it looks like a lot has changed, a lot of what you know and love about Vue is still the same; but we wanted to be as thorough as possible and provide detailed explanations and examples for every documented change.
+たくさん変わったように見えますが、Vue について皆さんが知っていることや気に入っていることの多くは変わりません。しかしできる限り徹底して、ドキュメント化されたすべての変更について詳細な説明と例を提供したいと考えました。
 
-## Details
+## 詳細
 
-### Global API
+### グローバル API
 
-- [Global Vue API is changed to use an application instance](./global-api.html)
-- [Global and internal APIs have been restructured to be tree-shakable](./global-api-treeshaking.html)
+- [グローバル Vue API はアプリケーションインスタンスを使用するように変更されました](./global-api.html)
+- [グローバル API と内部 API が再構築され、ツリーシェイキングが可能になりました](./global-api-treeshaking.html)
 
-### Template Directives
+### テンプレートディレクティブ
 
-- [`v-model` usage on components has been reworked, replacing `v-bind.sync`](./v-model.html)
-- [`key` usage on `<template v-for>` and non-`v-for` nodes has changed](./key-attribute.html)
-- [`v-if` and `v-for` precedence when used on the same element has changed](./v-if-v-for.html)
-- [`v-bind="object"` is now order-sensitive](./v-bind.html)
-- [`v-on:event.native` modifier has been removed](./v-on-native-modifier-removed.md)
+- [コンポーネントでの `v-model` の使用方法が見直され、`v-bind.sync` を置き換えます](./v-model.html)
+- [`<template v-for>` や `v-for` でないノードでの `key` の使い方が変更されました](./key-attribute.html)
+- [`v-if` と `v-for` を同じ要素で使用した場合の優先順位が変更されました](./v-if-v-for.html)
+- [`v-bind="object"` は順序に依存するようになりました](./v-bind.html)
+- [`v-on:event.native` 修飾子は削除されました](./v-on-native-modifier-removed.md)
 
-### Components
+### コンポーネント
 
-- [Functional components can only be created using a plain function](./functional-components.html)
-- [`functional` attribute on single-file component (SFC) `<template>` and `functional` component option are deprecated](./functional-components.html)
-- [Async components now require `defineAsyncComponent` method to be created](./async-components.html)
-- [Component events should now be declared with the `emits` option](./emits-option.md)
+- [関数型コンポーネントは普通の関数のみで作成できます](./functional-components.html)
+- [単一ファイルコンポーネント（SFC）での `<template>` の `functional` 属性と、コンポーネントオプションの `functional` は非推奨です](./functional-components.html)
+- [非同期コンポーネントを作成するには `defineAsyncComponent` メソッドが必要になりました](./async-components.html)
+- [コンポーネントイベントは `emits` オプションで宣言する必要があります](./emits-option.md)
 
-### Render Function
+### レンダー関数
 
-- [Render function API changed](./render-function-api.html)
-- [`$scopedSlots` property is removed and all slots are exposed via `$slots` as functions](./slots-unification.html)
-- [`$listeners` has been removed / merged into `$attrs`](./listeners-removed)
-- [`$attrs` now includes `class` and `style` attributes](./attrs-includes-class-style.md)
+- [レンダー関数の API が変更されました](./render-function-api.html)
+- [`$scopedSlots` プロパティーは削除され、すべてのスロットが `$slots` で関数として公開されます](./slots-unification.html)
+- [`$listeners` は削除され、`$attrs` に統合されました](./listeners-removed)
+- [`$attrs` には `class` と `style` 属性が含まれるようになりました](./attrs-includes-class-style.md)
 
-### Custom Elements
+### カスタム要素
 
-- [Custom element checks are now performed during template compilation](./custom-elements-interop.html)
-- [Special `is` attribute usage is restricted to the reserved `<component>` tag only](./custom-elements-interop.html#customized-built-in-elements)
+- [テンプレートのコンパイル時に、カスタム要素のチェックが行われるようになりました](./custom-elements-interop.html)
+- [特別な `is` 属性の使用は、予約済みである `<component>` タグのみに制限されます](./custom-elements-interop.html#customized-built-in-elements)
 
-### Other Minor Changes
+### その他の小さな変更
 
-- The `destroyed` lifecycle option has been renamed to `unmounted`
-- The `beforeDestroy` lifecycle option has been renamed to `beforeUnmount`
-- [Props `default` factory function no longer has access to `this` context](./props-default-this.html)
-- [Custom directive API changed to align with component lifecycle and `binding.expression` removed](./custom-directives.html)
-- [The `data` option should always be declared as a function](./data-option.html)
-- [The `data` option from mixins is now merged shallowly](./data-option.html#mixin-merge-behavior-change)
-- [Attributes coercion strategy changed](./attribute-coercion.html)
-- [Some transition classes got a rename](./transition.html)
-- [`<TransitionGroup>` now renders no wrapper element by default](./transition-group.html)
-- [When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.](./watch.html)
-- `<template>` tags with no special directives (`v-if/else-if/else`, `v-for`, or `v-slot`) are now treated as plain elements and will result in a native `<template>` element instead of rendering its inner content.
-- [Mounted application does not replace the element it's mounted to](./mount-changes.html)
-- [Lifecycle `hook:` events prefix changed to `vnode-`](./vnode-lifecycle-events.html)
+- ライフサイクルの `destroyed` オプションは `unmounted` に名称変更されました
+- ライフサイクルの `beforeDestroy` オプションは `beforeUnmount` に名称変更されました
+- [props の `default` ファクトリー関数は `this` コンテキストにアクセスできなくなりました](./props-default-this.html)
+- [カスタムディレクティブ API は、コンポーネントのライフサイクルに合わせて変更され、`binding.expression` は削除されました](./custom-directives.html)
+- [`data` オプションは、常に関数として宣言する必要があります](./data-option.html)
+- [mixins の `data` オプションは浅くマージされるようになりました](./data-option.html#mixin-merge-behavior-change)
+- [属性の型強制戦略が変更されました](./attribute-coercion.html)
+- [一部のトランジションクラス名が変更されました](./transition.html)
+- [`<TransitionGroup>` はデフォルトでラッパー要素をレンダリングしないようになりました](./transition-group.html)
+- [配列を監視している場合、コールバックは配列が置換されたときにのみトリガーされます。変更時にトリガーする必要がある場合は、`deep` オプションを指定する必要があります。](./watch.html)
+- 特別なディレクティブ（`v-if/else-if/else`, `v-for`, `v-slot`）を持たない `<template>` タグはプレーンな要素として扱われ、その内部コンテンツをレンダリングする代わりに、ネイティブの `<template>` 要素が生成されるようになりました。
+- [マウントされたアプリケーションは、そこにマウントされている要素を置き換えません](./mount-changes.html)
+- [ライフサイクルの `hook:` イベントプレフィックスが `vnode-` に変更されました](./vnode-lifecycle-events.html)
 
-### Removed APIs
+### 削除された API
 
-- [`keyCode` support as `v-on` modifiers](./keycode-modifiers.html)
-- [$on, $off and \$once instance methods](./events-api.html)
-- [Filters](./filters.html)
-- [Inline templates attributes](./inline-template-attribute.html)
-- [`$children` instance property](./children.html)
-- [`propsData` option](./props-data.html)
-- `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
-- Global functions `set` and `delete`, and the instance methods `$set` and `$delete`. They are no longer required with proxy-based change detection.
+- [`v-on` 修飾子としての `keyCode` サポート](./keycode-modifiers.html)
+- [$on, $off, \$once インスタンスメソッド](./events-api.html)
+- [フィルター](./filters.html)
+- [インラインテンプレート属性](./inline-template-attribute.html)
+- [`$children` インスタンスプロパティー](./children.html)
+- [`propsData` オプション](./props-data.html)
+- `$destroy` インスタンスメソッド。ユーザーは、個々の Vue コンポーネントのライフサイクルを手動で管理する必要がなくなりました。
+- グローバル関数の `set` と `delete`、インスタンスメソッドの `$set` と `$delete` は削除されました。プロキシベースの変更検出では不要になりました。

--- a/src/ja/breaking-changes/index.md
+++ b/src/ja/breaking-changes/index.md
@@ -1,0 +1,66 @@
+# Breaking Changes
+
+This page lists all Vue 3 breaking changes from Vue 2.
+
+While it looks like a lot has changed, a lot of what you know and love about Vue is still the same; but we wanted to be as thorough as possible and provide detailed explanations and examples for every documented change.
+
+## Details
+
+### Global API
+
+- [Global Vue API is changed to use an application instance](./global-api.html)
+- [Global and internal APIs have been restructured to be tree-shakable](./global-api-treeshaking.html)
+
+### Template Directives
+
+- [`v-model` usage on components has been reworked, replacing `v-bind.sync`](./v-model.html)
+- [`key` usage on `<template v-for>` and non-`v-for` nodes has changed](./key-attribute.html)
+- [`v-if` and `v-for` precedence when used on the same element has changed](./v-if-v-for.html)
+- [`v-bind="object"` is now order-sensitive](./v-bind.html)
+- [`v-on:event.native` modifier has been removed](./v-on-native-modifier-removed.md)
+
+### Components
+
+- [Functional components can only be created using a plain function](./functional-components.html)
+- [`functional` attribute on single-file component (SFC) `<template>` and `functional` component option are deprecated](./functional-components.html)
+- [Async components now require `defineAsyncComponent` method to be created](./async-components.html)
+- [Component events should now be declared with the `emits` option](./emits-option.md)
+
+### Render Function
+
+- [Render function API changed](./render-function-api.html)
+- [`$scopedSlots` property is removed and all slots are exposed via `$slots` as functions](./slots-unification.html)
+- [`$listeners` has been removed / merged into `$attrs`](./listeners-removed)
+- [`$attrs` now includes `class` and `style` attributes](./attrs-includes-class-style.md)
+
+### Custom Elements
+
+- [Custom element checks are now performed during template compilation](./custom-elements-interop.html)
+- [Special `is` attribute usage is restricted to the reserved `<component>` tag only](./custom-elements-interop.html#customized-built-in-elements)
+
+### Other Minor Changes
+
+- The `destroyed` lifecycle option has been renamed to `unmounted`
+- The `beforeDestroy` lifecycle option has been renamed to `beforeUnmount`
+- [Props `default` factory function no longer has access to `this` context](./props-default-this.html)
+- [Custom directive API changed to align with component lifecycle and `binding.expression` removed](./custom-directives.html)
+- [The `data` option should always be declared as a function](./data-option.html)
+- [The `data` option from mixins is now merged shallowly](./data-option.html#mixin-merge-behavior-change)
+- [Attributes coercion strategy changed](./attribute-coercion.html)
+- [Some transition classes got a rename](./transition.html)
+- [`<TransitionGroup>` now renders no wrapper element by default](./transition-group.html)
+- [When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.](./watch.html)
+- `<template>` tags with no special directives (`v-if/else-if/else`, `v-for`, or `v-slot`) are now treated as plain elements and will result in a native `<template>` element instead of rendering its inner content.
+- [Mounted application does not replace the element it's mounted to](./mount-changes.html)
+- [Lifecycle `hook:` events prefix changed to `vnode-`](./vnode-lifecycle-events.html)
+
+### Removed APIs
+
+- [`keyCode` support as `v-on` modifiers](./keycode-modifiers.html)
+- [$on, $off and \$once instance methods](./events-api.html)
+- [Filters](./filters.html)
+- [Inline templates attributes](./inline-template-attribute.html)
+- [`$children` instance property](./children.html)
+- [`propsData` option](./props-data.html)
+- `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
+- Global functions `set` and `delete`, and the instance methods `$set` and `$delete`. They are no longer required with proxy-based change detection.

--- a/src/ja/breaking-changes/inline-template-attribute.md
+++ b/src/ja/breaking-changes/inline-template-attribute.md
@@ -1,0 +1,84 @@
+---
+badges:
+  - breaking
+---
+
+# Inline Template Attribute <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Support for the [inline-template feature](https://vuejs.org/v2/guide/components-edge-cases.html#Inline-Templates) has been removed.
+
+## 2.x Syntax
+
+In 2.x, Vue provided the `inline-template` attribute on child components to use its inner content as its template instead of treating it as distributed content.
+
+```html
+<my-component inline-template>
+  <div>
+    <p>These are compiled as the component's own template.</p>
+    <p>Not parent's transclusion content.</p>
+  </div>
+</my-component>
+```
+
+## 3.x Syntax
+
+This feature will no longer be supported.
+
+## Migration Strategy
+
+Most of the use cases for `inline-template` assumes a no-build-tool setup, where all templates are written directly inside the HTML page.
+
+[Migration build flag: `COMPILER_INLINE_TEMPLATE`](../migration-build.html#compat-configuration)
+
+### Option #1: Use `<script>` tag
+
+The most straightforward workaround in such cases is using `<script>` with an alternative type:
+
+```html
+<script type="text/html" id="my-comp-template">
+  <div>{{ hello }}</div>
+</script>
+```
+
+And in the component, target the template using a selector:
+
+```js
+const MyComp = {
+  template: '#my-comp-template'
+  // ...
+}
+```
+
+This doesn't require any build setup, works in all browsers, is not subject to any in-DOM HTML parsing caveats (e.g. you can use camelCase prop names), and provides proper syntax highlighting in most IDEs. In traditional server-side frameworks, these templates can be split out into server template partials (included into the main HTML template) for better maintainability.
+
+### Option #2: Default Slot
+
+A component previously using `inline-template` can also be refactored using the default slot - which makes the data scoping more explicit while preserving the convenience of writing child content inline:
+
+```html
+<!-- 2.x Syntax -->
+<my-comp inline-template :msg="parentMsg">
+  {{ msg }} {{ childState }}
+</my-comp>
+
+<!-- Default Slot Version -->
+<my-comp v-slot="{ childState }">
+  {{ parentMsg }} {{ childState }}
+</my-comp>
+```
+
+The child, instead of providing no template, should now render the default slot\*:
+
+```html
+<!--
+  in child template, render default slot while passing
+  in necessary private state of child.
+-->
+<template>
+  <slot :childState="childState" />
+</template>
+```
+
+> - Note: In 3.x, slots can be rendered as the root with native [fragments](../new/fragments) support!

--- a/src/ja/breaking-changes/inline-template-attribute.md
+++ b/src/ja/breaking-changes/inline-template-attribute.md
@@ -7,7 +7,7 @@ badges:
 
 ## Overview
 
-Support for the [inline-template feature](https://vuejs.org/v2/guide/components-edge-cases.html#Inline-Templates) has been removed.
+Support for the [inline-template feature](https://v2.ja.vuejs.org/v2/guide/components-edge-cases#%E3%82%A4%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88) has been removed.
 
 ## 2.x Syntax
 

--- a/src/ja/breaking-changes/key-attribute.md
+++ b/src/ja/breaking-changes/key-attribute.md
@@ -18,7 +18,7 @@ The `key` special attribute is used as a hint for Vue's virtual DOM algorithm to
 - [List Rendering: Maintaining State](https://ja.vuejs.org/guide/essentials/list.html#maintaining-state-with-key)
 - [API Reference: `key` Special Attribute](https://ja.vuejs.org/api/built-in-special-attributes.html#key)
 
-## On conditional branches
+## On conditional branches {#on-conditional-branches}
 
 In Vue 2.x, it was recommended to use `key`s on `v-if`/`v-else`/`v-else-if` branches.
 
@@ -52,7 +52,7 @@ The breaking change is that if you manually provide `key`s, each branch must use
 <div v-else key="b">No</div>
 ```
 
-## With `<template v-for>`
+## With `<template v-for>` {#with-template-v-for}
 
 In Vue 2.x, a `<template>` tag could not have a `key`. Instead, you could place the `key`s on each of its children.
 

--- a/src/ja/breaking-changes/key-attribute.md
+++ b/src/ja/breaking-changes/key-attribute.md
@@ -15,8 +15,8 @@ badges:
 
 The `key` special attribute is used as a hint for Vue's virtual DOM algorithm to keep track of a node's identity. That way, Vue knows when it can reuse and patch existing nodes and when it needs to reorder or recreate them. For more information, see the following sections:
 
-- [List Rendering: Maintaining State](https://vuejs.org/guide/essentials/list.html#maintaining-state-with-key)
-- [API Reference: `key` Special Attribute](https://vuejs.org/api/built-in-special-attributes.html#key)
+- [List Rendering: Maintaining State](https://ja.vuejs.org/guide/essentials/list.html#maintaining-state-with-key)
+- [API Reference: `key` Special Attribute](https://ja.vuejs.org/api/built-in-special-attributes.html#key)
 
 ## On conditional branches
 

--- a/src/ja/breaking-changes/key-attribute.md
+++ b/src/ja/breaking-changes/key-attribute.md
@@ -1,0 +1,91 @@
+---
+badges:
+  - breaking
+---
+
+# `key` Attribute <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **NEW:** `key`s are no longer necessary on `v-if`/`v-else`/`v-else-if` branches, since Vue now automatically generates unique `key`s.
+  - **BREAKING:** If you manually provide `key`s, then each branch must use a unique `key`. You can no longer intentionally use the same `key` to force branch reuse.
+- **BREAKING:** `<template v-for>` `key` should be placed on the `<template>` tag (rather than on its children).
+
+## Background
+
+The `key` special attribute is used as a hint for Vue's virtual DOM algorithm to keep track of a node's identity. That way, Vue knows when it can reuse and patch existing nodes and when it needs to reorder or recreate them. For more information, see the following sections:
+
+- [List Rendering: Maintaining State](https://vuejs.org/guide/essentials/list.html#maintaining-state-with-key)
+- [API Reference: `key` Special Attribute](https://vuejs.org/api/built-in-special-attributes.html#key)
+
+## On conditional branches
+
+In Vue 2.x, it was recommended to use `key`s on `v-if`/`v-else`/`v-else-if` branches.
+
+```html
+<!-- Vue 2.x -->
+<div v-if="condition" key="yes">Yes</div>
+<div v-else key="no">No</div>
+```
+
+The example above still works in Vue 3.x. However, we no longer recommend using the `key` attribute on `v-if`/`v-else`/`v-else-if` branches, since unique `key`s are now automatically generated on conditional branches if you don't provide them.
+
+```html
+<!-- Vue 3.x -->
+<div v-if="condition">Yes</div>
+<div v-else>No</div>
+```
+
+The breaking change is that if you manually provide `key`s, each branch must use a unique `key`. In most cases, you can remove these `key`s.
+
+```html
+<!-- Vue 2.x -->
+<div v-if="condition" key="a">Yes</div>
+<div v-else key="a">No</div>
+
+<!-- Vue 3.x (recommended solution: remove keys) -->
+<div v-if="condition">Yes</div>
+<div v-else>No</div>
+
+<!-- Vue 3.x (alternate solution: make sure the keys are always unique) -->
+<div v-if="condition" key="a">Yes</div>
+<div v-else key="b">No</div>
+```
+
+## With `<template v-for>`
+
+In Vue 2.x, a `<template>` tag could not have a `key`. Instead, you could place the `key`s on each of its children.
+
+```html
+<!-- Vue 2.x -->
+<template v-for="item in list">
+  <div :key="'heading-' + item.id">...</div>
+  <span :key="'content-' + item.id">...</span>
+</template>
+```
+
+In Vue 3.x, the `key` should be placed on the `<template>` tag instead.
+
+```html
+<!-- Vue 3.x -->
+<template v-for="item in list" :key="item.id">
+  <div>...</div>
+  <span>...</span>
+</template>
+```
+
+Similarly, when using `<template v-for>` with a child that uses `v-if`, the `key` should be moved up to the `<template>` tag.
+
+```html
+<!-- Vue 2.x -->
+<template v-for="item in list">
+  <div v-if="item.isVisible" :key="item.id">...</div>
+  <span v-else :key="item.id">...</span>
+</template>
+
+<!-- Vue 3.x -->
+<template v-for="item in list" :key="item.id">
+  <div v-if="item.isVisible">...</div>
+  <span v-else>...</span>
+</template>
+```

--- a/src/ja/breaking-changes/keycode-modifiers.md
+++ b/src/ja/breaking-changes/keycode-modifiers.md
@@ -1,0 +1,72 @@
+---
+badges:
+  - breaking
+---
+
+# KeyCode Modifiers <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Here is a quick summary of what has changed:
+
+- **BREAKING**: Using numbers, i.e. keyCodes, as `v-on` modifiers is no longer supported
+- **BREAKING**: `config.keyCodes` is no longer supported
+
+## 2.x Syntax
+
+In Vue 2, `keyCodes` were supported as a way to modify a `v-on` method.
+
+```html
+<!-- keyCode version -->
+<input v-on:keyup.13="submit" />
+
+<!-- alias version -->
+<input v-on:keyup.enter="submit" />
+```
+
+In addition, you could define your own aliases via the global `config.keyCodes` option.
+
+```js
+Vue.config.keyCodes = {
+  f1: 112
+}
+```
+
+```html
+<!-- keyCode version -->
+<input v-on:keyup.112="showHelpText" />
+
+<!-- custom alias version -->
+<input v-on:keyup.f1="showHelpText" />
+```
+
+## 3.x Syntax
+
+Since [`KeyboardEvent.keyCode` has been deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode), it no longer makes sense for Vue 3 to continue supporting this as well. As a result, it is now recommended to use the kebab-case name for any key you want to use as a modifier.
+
+```html
+<!-- Vue 3 Key Modifier on v-on -->
+<input v-on:keyup.page-down="nextPage">
+
+<!-- Matches both q and Q -->
+<input v-on:keypress.q="quit">
+```
+
+As a result, this means that `config.keyCodes` is now also deprecated and will no longer be supported.
+
+## Migration Strategy
+
+For those using `keyCode` in their codebase, we recommend converting them to their kebab-cased named equivalents.
+
+The keys for some punctuation marks can just be included literally. e.g. For the `,` key:
+
+```html
+<input v-on:keypress.,="commaPress">
+```
+
+Limitations of the syntax prevent certain characters from being matched, such as `"`, `'`, `/`, `=`, `>`, and `.`. For those characters you should check `event.key` inside the listener instead.
+
+[Migration build flags:](../migration-build.html#compat-configuration)
+
+- `CONFIG_KEY_CODES`
+- `V_ON_KEYCODE_MODIFIER`

--- a/src/ja/breaking-changes/listeners-removed.md
+++ b/src/ja/breaking-changes/listeners-removed.md
@@ -1,0 +1,76 @@
+---
+title: $listeners removed
+badges:
+  - breaking
+---
+
+# `$listeners` removed <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The `$listeners` object has been removed in Vue 3. Event listeners are now part of `$attrs`:
+
+```js
+{
+  text: 'this is an attribute',
+  onClose: () => console.log('close Event triggered')
+}
+```
+
+## 2.x Syntax
+
+In Vue 2, you can access attributes passed to your components with `this.$attrs`, and event listeners with `this.$listeners`.
+In combination with `inheritAttrs: false`, they allow the developer to apply these attributes and listeners to some other element instead of the root element:
+
+```html
+<template>
+  <label>
+    <input type="text" v-bind="$attrs" v-on="$listeners" />
+  </label>
+</template>
+<script>
+  export default {
+    inheritAttrs: false
+  }
+</script>
+```
+
+## 3.x Syntax
+
+In Vue 3's virtual DOM, event listeners are now just attributes, prefixed with `on`, and as such are part of the `$attrs` object, so `$listeners` has been removed.
+
+```vue
+<template>
+  <label>
+    <input type="text" v-bind="$attrs" />
+  </label>
+</template>
+<script>
+export default {
+  inheritAttrs: false
+}
+</script>
+```
+
+If this component received an `id` attribute and a `v-on:close` listener, the `$attrs` object will now look like this:
+
+```js
+{
+  id: 'my-input',
+  onClose: () => console.log('close Event triggered')
+}
+```
+
+## Migration Strategy
+
+Remove all usages of `$listeners`.
+
+[Migration build flag: `INSTANCE_LISTENERS`](../migration-build.html#compat-configuration)
+
+## See also
+
+- [Relevant RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
+- [Migration guide - `$attrs`includes `class` & `style` ](./attrs-includes-class-style.md)
+- [Migration guide - Changes in the Render Functions API](./render-function-api.md)
+- [Migration guide - New Emits Option](./emits-option.md)
+- [Migration guide - `.native` modifier removed](./v-on-native-modifier-removed.md)

--- a/src/ja/breaking-changes/mount-changes.md
+++ b/src/ja/breaking-changes/mount-changes.md
@@ -1,0 +1,98 @@
+---
+title: 'Mount API changes'
+badges:
+  - breaking
+---
+
+# Mounted application does not replace the element <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+In Vue 2.x, when mounting an application that has a `template`, the rendered content replaces the element we mount to. In Vue 3.x, the rendered application is appended as a child of such an element, replacing element's `innerHTML`.
+
+## 2.x Syntax
+
+In Vue 2.x, we pass an HTML element selector to `new Vue()` or `$mount`:
+
+```js
+new Vue({
+  el: '#app',
+  data() {
+    return {
+      message: 'Hello Vue!'
+    }
+  },
+  template: `
+    <div id="rendered">{{ message }}</div>
+  `
+})
+
+// or
+const app = new Vue({
+  data() {
+    return {
+      message: 'Hello Vue!'
+    }
+  },
+  template: `
+    <div id="rendered">{{ message }}</div>
+  `
+})
+
+app.$mount('#app')
+```
+
+When we mount this application to the page that has a `div` with the passed selector (in our case, it's `id="app"`):
+
+```html
+<body>
+  <div id="app">
+    Some app content
+  </div>
+</body>
+```
+
+in the rendered result, the mentioned `div` will be replaced with the rendered application content:
+
+```html
+<body>
+  <div id="rendered">Hello Vue!</div>
+</body>
+```
+
+## 3.x Syntax
+
+In Vue 3.x, when we mount an application, its rendered content will replace the `innerHTML` of the element we pass to `mount`:
+
+```js
+const app = Vue.createApp({
+  data() {
+    return {
+      message: 'Hello Vue!'
+    }
+  },
+  template: `
+    <div id="rendered">{{ message }}</div>
+  `
+})
+
+app.mount('#app')
+```
+
+When this app is mounted to the page that has a `div` with `id="app"`, this will result in:
+
+```html
+<body>
+  <div id="app" data-v-app="">
+    <div id="rendered">Hello Vue!</div>
+  </div>
+</body>
+```
+
+## Migration Strategy
+
+[Migration build flag: `GLOBAL_MOUNT_CONTAINER`](../migration-build.html#compat-configuration)
+
+## See Also
+
+- [`mount` API](https://vuejs.org/api/application.html#app-mount)

--- a/src/ja/breaking-changes/mount-changes.md
+++ b/src/ja/breaking-changes/mount-changes.md
@@ -95,4 +95,4 @@ When this app is mounted to the page that has a `div` with `id="app"`, this will
 
 ## See Also
 
-- [`mount` API](https://vuejs.org/api/application.html#app-mount)
+- [`mount` API](https://ja.vuejs.org/api/application.html#app-mount)

--- a/src/ja/breaking-changes/props-data.md
+++ b/src/ja/breaking-changes/props-data.md
@@ -1,0 +1,41 @@
+---
+badges:
+  - removed
+---
+
+# `propsData` <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The `propsData` option, used to pass props to the Vue instance during its creation, is removed. To pass props to the root component of a Vue 3 application, use the second argument of [createApp](https://vuejs.org/api/application.html#createapp).
+
+## 2.x Syntax
+
+In 2.x, we were able to pass props to a Vue instance during its creation:
+
+```js
+const Comp = Vue.extend({
+  props: ['username'],
+  template: '<div>{{ username }}</div>'
+})
+
+new Comp({
+  propsData: {
+    username: 'Evan'
+  }
+})
+```
+
+## 3.x Update
+
+The `propsData` option has been removed. If you need to pass props to the root component instance during its creation, you should use the second argument of `createApp`:
+
+```js
+const app = createApp(
+  {
+    props: ['username'],
+    template: '<div>{{ username }}</div>'
+  },
+  { username: 'Evan' }
+)
+```

--- a/src/ja/breaking-changes/props-data.md
+++ b/src/ja/breaking-changes/props-data.md
@@ -7,7 +7,7 @@ badges:
 
 ## Overview
 
-The `propsData` option, used to pass props to the Vue instance during its creation, is removed. To pass props to the root component of a Vue 3 application, use the second argument of [createApp](https://vuejs.org/api/application.html#createapp).
+The `propsData` option, used to pass props to the Vue instance during its creation, is removed. To pass props to the root component of a Vue 3 application, use the second argument of [createApp](https://ja.vuejs.org/api/application.html#createapp).
 
 ## 2.x Syntax
 

--- a/src/ja/breaking-changes/props-default-this.md
+++ b/src/ja/breaking-changes/props-default-this.md
@@ -12,7 +12,7 @@ Instead:
 
 - Raw props received by the component are passed to the default function as argument;
 
-- The [inject](https://vuejs.org/api/composition-api-dependency-injection.html#inject) API can be used inside default functions.
+- The [inject](https://ja.vuejs.org/api/composition-api-dependency-injection.html#inject) API can be used inside default functions.
 
 ```js
 import { inject } from 'vue'

--- a/src/ja/breaking-changes/props-default-this.md
+++ b/src/ja/breaking-changes/props-default-this.md
@@ -1,0 +1,36 @@
+---
+title: Props Default Function this Access
+badges:
+  - breaking
+---
+
+# Props Default Function `this` Access <MigrationBadges :badges="$frontmatter.badges" />
+
+Props default value factory functions no longer have access to `this`.
+
+Instead:
+
+- Raw props received by the component are passed to the default function as argument;
+
+- The [inject](https://vuejs.org/api/composition-api-dependency-injection.html#inject) API can be used inside default functions.
+
+```js
+import { inject } from 'vue'
+
+export default {
+  props: {
+    theme: {
+      default (props) {
+        // `props` is the raw values passed to the component,
+        // before any type / default coercions
+        // can also use `inject` to access injected properties
+        return inject('theme', 'default-theme')
+      }
+    }
+  }
+}
+```
+
+## Migration Strategy
+
+[Migration build flag: `PROPS_DEFAULT_THIS`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/render-function-api.md
+++ b/src/ja/breaking-changes/render-function-api.md
@@ -143,4 +143,4 @@ For more information, see [The Render Function Api Change RFC](https://github.co
 
 ## Next Steps
 
-See [Render Function Guide](https://vuejs.org/guide/extras/render-function.html) for more detailed documentation!
+See [Render Function Guide](https://ja.vuejs.org/guide/extras/render-function.html) for more detailed documentation!

--- a/src/ja/breaking-changes/render-function-api.md
+++ b/src/ja/breaking-changes/render-function-api.md
@@ -1,0 +1,146 @@
+---
+badges:
+  - breaking
+---
+
+# Render Function API <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+This change will not affect `<template>` users.
+
+Here is a quick summary of what has changed:
+
+- `h` is now globally imported instead of passed to render functions as an argument
+- render function arguments changed to be more consistent between stateful and functional components
+- VNodes now have a flat props structure
+
+For more information, read on!
+
+## Render Function Argument
+
+### 2.x Syntax
+
+In 2.x, the `render` function would automatically receive the `h` function (which is a conventional alias for `createElement`) as an argument:
+
+```js
+// Vue 2 Render Function Example
+export default {
+  render(h) {
+    return h('div')
+  }
+}
+```
+
+### 3.x Syntax
+
+In 3.x, `h` is now globally imported instead of being automatically passed as an argument.
+
+```js
+// Vue 3 Render Function Example
+import { h } from 'vue'
+
+export default {
+  render() {
+    return h('div')
+  }
+}
+```
+
+## VNode Props Format
+
+### 2.x Syntax
+
+In 2.x, `domProps` contained a nested list within the VNode props:
+
+```js
+// 2.x
+{
+  staticClass: 'button',
+  class: {'is-outlined': isOutlined },
+  staticStyle: { color: '#34495E' },
+  style: { backgroundColor: buttonColor },
+  attrs: { id: 'submit' },
+  domProps: { innerHTML: '' },
+  on: { click: submitForm },
+  key: 'submit-button'
+}
+```
+
+### 3.x Syntax
+
+In 3.x, the entire VNode props structure is flattened. Using the example from above, here is what it would look like now.
+
+```js
+// 3.x Syntax
+{
+  class: ['button', { 'is-outlined': isOutlined }],
+  style: [{ color: '#34495E' }, { backgroundColor: buttonColor }],
+  id: 'submit',
+  innerHTML: '',
+  onClick: submitForm,
+  key: 'submit-button'
+}
+```
+
+## Registered Component
+
+### 2.x Syntax
+
+In 2.x, when a component has been registered, the render function would work well when passing the component's name as a string to the first argument:
+
+```js
+// 2.x
+Vue.component('button-counter', {
+  data() {
+    return {
+      count: 0
+    }
+  }
+  template: `
+    <button @click="count++">
+      Clicked {{ count }} times.
+    </button>
+  `
+})
+
+export default {
+  render(h) {
+    return h('button-counter')
+  }
+}
+```
+
+### 3.x Syntax
+
+In 3.x, with VNodes being context-free, we can no longer use a string ID to implicitly lookup registered components. Instead, we need to use an imported `resolveComponent` method:
+
+```js
+// 3.x
+import { h, resolveComponent } from 'vue'
+
+export default {
+  setup() {
+    const ButtonCounter = resolveComponent('button-counter')
+    return () => h(ButtonCounter)
+  }
+}
+```
+
+For more information, see [The Render Function Api Change RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0008-render-function-api-change.md#context-free-vnodes).
+
+## Migration Strategy
+
+[Migration build flag: `RENDER_FUNCTION`](../migration-build.html#compat-configuration)
+
+### Library Authors
+
+`h` being globally imported means that any library that contains Vue components will include `import { h } from 'vue'` somewhere. As a result, this creates a bit of overhead since it requires library authors to properly configure the externalization of Vue in their build setup:
+
+- Vue should not be bundled into the library
+- For module builds, the import should be left alone and be handled by the end user bundler
+- For UMD / browser builds, it should try the global Vue.h first and fallback to require calls
+
+## Next Steps
+
+See [Render Function Guide](https://vuejs.org/guide/extras/render-function.html) for more detailed documentation!

--- a/src/ja/breaking-changes/slots-unification.md
+++ b/src/ja/breaking-changes/slots-unification.md
@@ -1,0 +1,67 @@
+---
+badges:
+  - breaking
+---
+
+# Slots Unification <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+This change unifies normal and scoped slots in 3.x.
+
+Here is a quick summary of what has changed:
+
+- `this.$slots` now exposes slots as functions
+- **BREAKING**: `this.$scopedSlots` is removed
+
+For more information, read on!
+
+## 2.x Syntax
+
+When using the render function, i.e., `h`, 2.x used to define the `slot` data property on the content nodes.
+
+```js
+// 2.x Syntax
+h(LayoutComponent, [
+  h('div', { slot: 'header' }, this.header),
+  h('div', { slot: 'content' }, this.content)
+])
+```
+
+In addition, when referencing scoped slots, they could be referenced using the following syntax:
+
+```js
+// 2.x Syntax
+this.$scopedSlots.header
+```
+
+## 3.x Syntax
+
+In 3.x, slots are defined as children of the current node as an object:
+
+```js
+// 3.x Syntax
+h(LayoutComponent, {}, {
+  header: () => h('div', this.header),
+  content: () => h('div', this.content)
+})
+```
+
+And when you need to reference scoped slots programmatically, they are now unified into the `$slots` option.
+
+```js
+// 2.x Syntax
+this.$scopedSlots.header
+
+// 3.x Syntax
+this.$slots.header()
+```
+
+## Migration Strategy
+
+A majority of the change has already been shipped in 2.6. As a result, the migration can happen in one step:
+
+1. Replace all `this.$scopedSlots` occurrences with `this.$slots` in 3.x.
+2. Replace all occurrences of `this.$slots.mySlot` with `this.$slots.mySlot()`
+
+[Migration build flag: `INSTANCE_SCOPED_SLOTS`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/transition-as-root.md
+++ b/src/ja/breaking-changes/transition-as-root.md
@@ -1,0 +1,61 @@
+---
+badges:
+  - breaking
+---
+
+# Transition as Root <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+Using a `<transition>` as a component's root will no longer trigger transitions when the component is toggled from the outside.
+
+## 2.x Behavior
+
+In Vue 2, it was possible to trigger a transition from outside a component by using a `<transition>` as the component's root:
+
+```html
+<!-- modal component -->
+<template>
+  <transition>
+    <div class="modal"><slot/></div>
+  </transition>
+</template>
+```
+
+```html
+<!-- usage -->
+<modal v-if="showModal">hello</modal>
+```
+
+Toggling the value of `showModal` would trigger a transition inside the modal component.
+
+This worked by accident, not by design. A `<transition>` is supposed to be triggered by changes to its children, not by toggling the `<transition>` itself.
+
+This quirk has now been removed.
+
+## Migration Strategy
+
+A similar effect can be achieved by passing a prop to the component instead:
+
+```vue
+<template>
+  <transition>
+    <div v-if="show" class="modal"><slot/></div>
+  </transition>
+</template>
+<script>
+export default {
+  props: ['show']
+}
+</script>
+```
+
+```html
+<!-- usage -->
+<modal :show="showModal">hello</modal>
+```
+
+## See also
+
+- [Some transition classes got a rename](./transition.html)
+- [`<TransitionGroup>` now renders no wrapper element by default](./transition-group.html)

--- a/src/ja/breaking-changes/transition-group.md
+++ b/src/ja/breaking-changes/transition-group.md
@@ -1,0 +1,45 @@
+---
+title: Transition Group Root Element
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+`<transition-group>` no longer renders a root element by default, but can still create one with the `tag` attribute.
+
+## 2.x Syntax
+
+In Vue 2, `<transition-group>`, like other custom components, needed a root element, which by default was a `<span>` but was customizable via the `tag` attribute.
+
+```html
+<transition-group tag="ul">
+  <li v-for="item in items" :key="item">
+    {{ item }}
+  </li>
+</transition-group>
+```
+
+## 3.x Syntax
+
+In Vue 3, we have [fragment support](../new/fragments.html), so components no longer _need_ a root node. Consequently, `<transition-group>` no longer renders one by default.
+
+- If you already have the `tag` attribute defined in your Vue 2 code, like in the example above, everything will work as before
+- If you didn't have one defined _and_ your styling or other behaviors relied on the presence of the `<span>` root element to work properly, simply add `tag="span"` to the `<transition-group>`:
+
+```html
+<transition-group tag="span">
+  <!-- -->
+</transition-group>
+```
+
+## Migration Strategy
+
+[Migration build flag: `TRANSITION_GROUP_ROOT`](../migration-build.html#compat-configuration)
+
+## See also
+
+- [Some transition classes got a rename](./transition.html)
+- [`<Transition>` as a root can no longer be toggled from the outside](./transition-as-root.html)

--- a/src/ja/breaking-changes/transition.md
+++ b/src/ja/breaking-changes/transition.md
@@ -1,0 +1,67 @@
+---
+title: Transition Class Change
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The `v-enter` transition class has been renamed to `v-enter-from` and the `v-leave` transition class has been renamed to `v-leave-from`.
+
+## 2.x Syntax
+
+Before v2.1.8, we had two transition classes for each transition direction: initial and active states.
+
+In v2.1.8, we introduced `v-enter-to` to address the timing gap between enter/leave transitions. However, for backward compatibility, the `v-enter` name was untouched:
+
+```css
+.v-enter,
+.v-leave-to {
+  opacity: 0;
+}
+
+.v-leave,
+.v-enter-to {
+  opacity: 1;
+}
+```
+
+This became confusing, as _enter_ and _leave_ were broad and not using the same naming convention as their class hook counterparts.
+
+## 3.x Update
+
+In order to be more explicit and legible, we have now renamed these initial state classes:
+
+```css
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+
+.v-leave-from,
+.v-enter-to {
+  opacity: 1;
+}
+```
+
+It's now much clearer what the difference between these states is.
+
+![Transition Diagram](/images/transitions.svg)
+
+The `<transition>` component's related prop names are also changed:
+
+- `leave-class` is renamed to `leave-from-class` (can be written as `leaveFromClass` in render functions or JSX)
+- `enter-class` is renamed to `enter-from-class` (can be written as `enterFromClass` in render functions or JSX)
+
+## Migration Strategy
+
+1. Replace instances of `.v-enter` to `.v-enter-from`
+2. Replace instances of `.v-leave` to `.v-leave-from`
+3. Replace instances of related prop names, as above.
+
+## See also
+
+- [`<Transition>` as a root can no longer be toggled from the outside](./transition-as-root.html)
+- [`<TransitionGroup>` now renders no wrapper element by default](./transition-group.html)

--- a/src/ja/breaking-changes/v-bind.md
+++ b/src/ja/breaking-changes/v-bind.md
@@ -1,0 +1,48 @@
+---
+title: v-bind Merge Behavior
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **BREAKING**: Order of bindings for v-bind will affect the rendering result.
+
+## Introduction
+
+When dynamically binding attributes on an element, a common scenario involves using both the `v-bind="object"` syntax as well as individual attributes in the same element. However, this raises questions as far as the priority of merging.
+
+## 2.x Syntax
+
+In 2.x, if an element has both `v-bind="object"` and an identical individual attribute defined, the individual attribute would always overwrite bindings in the `object`.
+
+```html
+<!-- template -->
+<div id="red" v-bind="{ id: 'blue' }"></div>
+<!-- result -->
+<div id="red"></div>
+```
+
+## 3.x Syntax
+
+In 3x, if an element has both `v-bind="object"` and an identical individual attribute defined, the order of how the bindings are declared determines how they are merged. In other words, rather than assuming developers want the individual attribute to always override what is defined in the `object`, developers now have more control over the desired merging behavior.
+
+```html
+<!-- template -->
+<div id="red" v-bind="{ id: 'blue' }"></div>
+<!-- result -->
+<div id="blue"></div>
+
+<!-- template -->
+<div v-bind="{ id: 'blue' }" id="red"></div>
+<!-- result -->
+<div id="red"></div>
+```
+
+## Migration Strategy
+
+If you are relying on this override functionality for `v-bind`, we currently recommend ensuring that your `v-bind` attribute is defined before individual attributes.
+
+[Migration build flag: `COMPILER_V_BIND_OBJECT_ORDER`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/v-if-v-for.md
+++ b/src/ja/breaking-changes/v-if-v-for.md
@@ -32,5 +32,5 @@ Rather than managing this at the template level, one method for accomplishing th
 
 ## See also
 
-- [List Rendering - Displaying Filtered/Sorted Results](https://vuejs.org/guide/essentials/list.html#displaying-filtered-sorted-results)
-- [List Rendering - `v-for` with `v-if`](https://vuejs.org/guide/essentials/list.html#v-for-with-v-if)
+- [List Rendering - Displaying Filtered/Sorted Results](https://ja.vuejs.org/guide/essentials/list.html#displaying-filtered-sorted-results)
+- [List Rendering - `v-for` with `v-if`](https://ja.vuejs.org/guide/essentials/list.html#v-for-with-v-if)

--- a/src/ja/breaking-changes/v-if-v-for.md
+++ b/src/ja/breaking-changes/v-if-v-for.md
@@ -1,0 +1,36 @@
+---
+title: v-if vs. v-for Precedence
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **BREAKING**: If used on the same element, `v-if` will have higher precedence than `v-for`
+
+## Introduction
+
+Two of the most commonly used directives in Vue.js are `v-if` and `v-for`. So it's no surprise that there comes a time when developers want to use both together. While this is not a recommended practice, there may be times when this is necessary, so we wanted to provide guidance for how it works.
+
+## 2.x Syntax
+
+In 2.x, when using `v-if` and `v-for` on the same element, `v-for` would take precedence.
+
+## 3.x Syntax
+
+In 3.x, `v-if` will always have the higher precedence than `v-for`.
+
+## Migration Strategy
+
+It is recommended to avoid using both on the same element due to the syntax ambiguity.
+
+Rather than managing this at the template level, one method for accomplishing this is to create a computed property that filters out a list for the visible elements.
+
+[Migration build flag: `COMPILER_V_IF_V_FOR_PRECEDENCE`](../migration-build.html#compat-configuration)
+
+## See also
+
+- [List Rendering - Displaying Filtered/Sorted Results](https://vuejs.org/guide/essentials/list.html#displaying-filtered-sorted-results)
+- [List Rendering - `v-for` with `v-if`](https://vuejs.org/guide/essentials/list.html#v-for-with-v-if)

--- a/src/ja/breaking-changes/v-model.md
+++ b/src/ja/breaking-changes/v-model.md
@@ -1,0 +1,196 @@
+---
+badges:
+  - breaking
+---
+
+# `v-model` <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+In terms of what has changed, at a high level:
+
+- **BREAKING:** When used on custom components, `v-model` prop and event default names are changed:
+  - prop: `value` -> `modelValue`;
+  - event: `input` -> `update:modelValue`;
+- **BREAKING:** `v-bind`'s `.sync` modifier and component `model` option are removed and replaced with an argument on `v-model`;
+- **NEW:** Multiple `v-model` bindings on the same component are possible now;
+- **NEW:** Added the ability to create custom `v-model` modifiers.
+
+For more information, read on!
+
+## Introduction
+
+When Vue 2.0 was released, the `v-model` directive required developers to always use the `value` prop. And if developers required different props for different purposes, they would have to resort to using `v-bind.sync`. In addition, this hard-coded relationship between `v-model` and `value` led to issues with how native elements and custom elements were handled.
+
+In 2.2 we introduced the `model` component option that allows the component to customize the prop and event to use for `v-model`. However, this still only allowed a single `v-model` to be used on the component.
+
+With Vue 3, the API for two-way data binding is being standardized in order to reduce confusion and to allow developers more flexibility with the `v-model` directive.
+
+## 2.x Syntax
+
+In 2.x, using a `v-model` on a component was an equivalent of passing a `value` prop and emitting an `input` event:
+
+```html
+<ChildComponent v-model="pageTitle" />
+
+<!-- would be shorthand for: -->
+
+<ChildComponent :value="pageTitle" @input="pageTitle = $event" />
+```
+
+If we wanted to change prop or event names to something different, we would need to add a `model` option to `ChildComponent` component:
+
+```html
+<!-- ParentComponent.vue -->
+
+<ChildComponent v-model="pageTitle" />
+```
+
+```js
+// ChildComponent.vue
+
+export default {
+  model: {
+    prop: 'title',
+    event: 'change'
+  },
+  props: {
+    // this allows using the `value` prop for a different purpose
+    value: String,
+    // use `title` as the prop which take the place of `value`
+    title: {
+      type: String,
+      default: 'Default title'
+    }
+  }
+}
+```
+
+So, `v-model` in this case would be a shorthand to
+
+```html
+<ChildComponent :title="pageTitle" @change="pageTitle = $event" />
+```
+
+### Using `v-bind.sync`
+
+In some cases, we might need "two-way binding" for a prop (sometimes in addition to existing `v-model` for the different prop). To do so, we recommended emitting events in the pattern of `update:myPropName`. For example, for `ChildComponent` from the previous example with the `title` prop, we could communicate the intent of assigning a new value with:
+
+```js
+this.$emit('update:title', newValue)
+```
+
+Then the parent could listen to that event and update a local data property, if it wants to. For example:
+
+```html
+<ChildComponent :title="pageTitle" @update:title="pageTitle = $event" />
+```
+
+For convenience, we had a shorthand for this pattern with the `.sync` modifier:
+
+```html
+<ChildComponent :title.sync="pageTitle" />
+```
+
+## 3.x Syntax
+
+In 3.x `v-model` on the custom component is an equivalent of passing a `modelValue` prop and emitting an `update:modelValue` event:
+
+```html
+<ChildComponent v-model="pageTitle" />
+
+<!-- would be shorthand for: -->
+
+<ChildComponent
+  :modelValue="pageTitle"
+  @update:modelValue="pageTitle = $event"
+/>
+```
+
+### `v-model` arguments
+
+To change a model name, instead of a `model` component option, now we can pass an _argument_ to `v-model`:
+
+```html
+<ChildComponent v-model:title="pageTitle" />
+
+<!-- would be shorthand for: -->
+
+<ChildComponent :title="pageTitle" @update:title="pageTitle = $event" />
+```
+
+![v-bind anatomy](/images/v-bind-instead-of-sync.png)
+
+This also serves as a replacement to `.sync` modifier and allows us to have multiple `v-model`s on the custom component.
+
+```html
+<ChildComponent v-model:title="pageTitle" v-model:content="pageContent" />
+
+<!-- would be shorthand for: -->
+
+<ChildComponent
+  :title="pageTitle"
+  @update:title="pageTitle = $event"
+  :content="pageContent"
+  @update:content="pageContent = $event"
+/>
+```
+
+### `v-model` modifiers
+
+In addition to 2.x hard-coded `v-model` modifiers like `.trim`, now 3.x supports custom modifiers:
+
+```html
+<ChildComponent v-model.capitalize="pageTitle" />
+```
+
+Read more about custom `v-model` modifiers in the [Component Events](http://vuejs.org/guide/components/events.html#usage-with-v-model) section.
+
+## Migration Strategy
+
+We recommend:
+
+- checking your codebase for `.sync` usage and replace it with `v-model`:
+
+  ```html
+  <ChildComponent :title.sync="pageTitle" />
+
+  <!-- to be replaced with -->
+
+  <ChildComponent v-model:title="pageTitle" />
+  ```
+
+- for all `v-model`s without arguments, make sure to change props and events name to `modelValue` and `update:modelValue` respectively
+
+  ```html
+  <ChildComponent v-model="pageTitle" />
+  ```
+
+  ```js
+  // ChildComponent.vue
+
+  export default {
+    props: {
+      modelValue: String // previously was `value: String`
+    },
+    emits: ['update:modelValue'],
+    methods: {
+      changePageTitle(title) {
+        this.$emit('update:modelValue', title) // previously was `this.$emit('input', title)`
+      }
+    }
+  }
+  ```
+
+[Migration build flags:](../migration-build.html#compat-configuration)
+
+- `COMPONENT_V_MODEL`
+- `COMPILER_V_BIND_SYNC`
+
+## Next Steps
+
+For more information on the new `v-model` syntax, see:
+
+- [Using `v-model` on Components](https://vuejs.org/guide/components/events.html#usage-with-v-model)
+- [`v-model` arguments](https://vuejs.org/guide/components/events.html#v-model-arguments)
+- [Handling `v-model` modifiers](https://vuejs.org/guide/components/events.html#usage-with-v-model)

--- a/src/ja/breaking-changes/v-model.md
+++ b/src/ja/breaking-changes/v-model.md
@@ -144,7 +144,7 @@ In addition to 2.x hard-coded `v-model` modifiers like `.trim`, now 3.x supports
 <ChildComponent v-model.capitalize="pageTitle" />
 ```
 
-Read more about custom `v-model` modifiers in the [Component Events](http://vuejs.org/guide/components/events.html#usage-with-v-model) section.
+Read more about custom `v-model` modifiers in the [Component Events](https://ja.vuejs.org/guide/components/v-model.html) section.
 
 ## Migration Strategy
 
@@ -191,6 +191,6 @@ We recommend:
 
 For more information on the new `v-model` syntax, see:
 
-- [Using `v-model` on Components](https://vuejs.org/guide/components/events.html#usage-with-v-model)
-- [`v-model` arguments](https://vuejs.org/guide/components/events.html#v-model-arguments)
-- [Handling `v-model` modifiers](https://vuejs.org/guide/components/events.html#usage-with-v-model)
+- [Using `v-model` on Components](https://ja.vuejs.org/guide/components/v-model.html)
+- [`v-model` arguments](https://ja.vuejs.org/guide/components/v-model.html#v-model-arguments)
+- [Handling `v-model` modifiers](https://ja.vuejs.org/guide/components/v-model.html#handling-v-model-modifiers)

--- a/src/ja/breaking-changes/v-on-native-modifier-removed.md
+++ b/src/ja/breaking-changes/v-on-native-modifier-removed.md
@@ -1,0 +1,59 @@
+---
+title: v-on.native modifier removed
+badges:
+  - breaking
+---
+
+# `v-on.native` modifier removed <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+The `.native` modifier for `v-on` has been removed.
+
+## 2.x Syntax
+
+Event listeners passed to a component with `v-on` are by default only triggered by emitting an event with `this.$emit`. To add a native DOM listener to the child component's root element instead, the `.native` modifier can be used:
+
+```html
+<my-component
+  v-on:close="handleComponentEvent"
+  v-on:click.native="handleNativeClickEvent"
+/>
+```
+
+## 3.x Syntax
+
+The `.native` modifier for `v-on` has been removed. At the same time, the [new `emits` option](./emits-option.md) allows the child to define which events it does indeed emit.
+
+Consequently, Vue will now add all event listeners that are _not_ defined as component-emitted events in the child as native event listeners to the child's root element (unless `inheritAttrs: false` has been set in the child's options).
+
+```html
+<my-component
+  v-on:close="handleComponentEvent"
+  v-on:click="handleNativeClickEvent"
+/>
+```
+
+`MyComponent.vue`
+
+```html
+<script>
+  export default {
+    emits: ['close']
+  }
+</script>
+```
+
+## Migration Strategy
+
+- remove all instances of the `.native` modifier.
+- ensure that all your components document their events with the `emits` option.
+
+[Migration build flag: `COMPILER_V_ON_NATIVE`](../migration-build.html#compat-configuration)
+
+## See also
+
+- [Relevant RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md#v-on-listener-fallthrough)
+- [Migration guide - New Emits Option](./emits-option.md)
+- [Migration guide - `$listeners` removed](./listeners-removed.md)
+- [Migration guide - Changes in the Render Functions API](./render-function-api.md)

--- a/src/ja/breaking-changes/vnode-lifecycle-events.md
+++ b/src/ja/breaking-changes/vnode-lifecycle-events.md
@@ -1,0 +1,42 @@
+---
+badges:
+  - breaking
+---
+
+# VNode Lifecycle Events <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+In Vue 2, it was possible to use events to listen for key stages in a component's lifecycle. These events had names that started with the prefix `hook:`, followed by the name of the corresponding lifecycle hook.
+
+In Vue 3, this prefix has been changed to `vue:`. In addition, these events are now available for HTML elements as well as components.
+
+## 2.x Syntax
+
+In Vue 2, the event name is the same as the equivalent lifecycle hook, prefixed with `hook:`:
+
+```html
+<template>
+  <child-component @hook:updated="onUpdated">
+</template>
+```
+
+## 3.x Syntax
+
+In Vue 3, the event name is prefixed with `vue:`:
+
+```html
+<template>
+  <child-component @vue:updated="onUpdated">
+</template>
+```
+
+## Migration Strategy
+
+In most cases it should just require changing the prefix. The lifecycle hooks `beforeDestroy` and `destroyed` have been renamed to `beforeUnmount` and `unmounted` respectively, so the corresponding event names will also need to be updated.
+
+[Migration build flags: `INSTANCE_EVENT_HOOKS`](../migration-build.html#compat-configuration)
+
+## See Also
+
+- [Migration guide - Events API](./events-api.html)

--- a/src/ja/breaking-changes/watch.md
+++ b/src/ja/breaking-changes/watch.md
@@ -1,0 +1,32 @@
+---
+title: Watch on Arrays
+badges:
+  - breaking
+---
+
+# {{ $frontmatter.title }} <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+- **BREAKING**: When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.
+
+## 3.x Syntax
+
+When using [the `watch` option](https://vuejs.org/api/options-state.html#watch) to watch an array, the callback will only trigger when the array is replaced. In other words, the watch callback will no longer be triggered on array mutation. To trigger on mutation, the `deep` option must be specified.
+
+```js
+watch: {
+  bookList: {
+    handler(val, oldVal) {
+      console.log('book list changed')
+    },
+    deep: true
+  },
+}
+```
+
+## Migration Strategy
+
+If you rely on watching array mutations, add the `deep` option to ensure that your callback is triggered correctly.
+
+[Migration build flag: `WATCH_ARRAY`](../migration-build.html#compat-configuration)

--- a/src/ja/breaking-changes/watch.md
+++ b/src/ja/breaking-changes/watch.md
@@ -12,7 +12,7 @@ badges:
 
 ## 3.x Syntax
 
-When using [the `watch` option](https://vuejs.org/api/options-state.html#watch) to watch an array, the callback will only trigger when the array is replaced. In other words, the watch callback will no longer be triggered on array mutation. To trigger on mutation, the `deep` option must be specified.
+When using [the `watch` option](https://ja.vuejs.org/api/options-state.html#watch) to watch an array, the callback will only trigger when the array is replaced. In other words, the watch callback will no longer be triggered on array mutation. To trigger on mutation, the `deep` option must be specified.
 
 ```js
 watch: {

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -1,10 +1,10 @@
-# Vue 3 Migration Guide
+# Vue 3 移行ガイド
 
-:::warning Vue 2 support will end on December 31st, 2023.
-Learn more about [Extended LTS](https://v2.vuejs.org/lts/) if upgrading to Vue 3 isn't feasible before the EOL date.
+:::warning Vue 2 のサポートは 2023 年 12 月 31 日をもって終了します。
+EOL の日付までに Vue 3 へのアップグレードが不可能な場合は、[Extended LTS](https://v2.vuejs.org/lts/) の詳細をご覧ください。
 :::
 
-This guide is primarily for users with prior Vue 2 experience who want to learn about the changes between Vue 2 and Vue 3. **This is not something you have to read from top to bottom before trying out Vue 3.** The recommended way to learn Vue 3 is by reading the [new documentation](https://ja.vuejs.org).
+このガイドは主に、Vue 2 の経験があり、Vue 3 との変更点について学びたいユーザーのためのものです。**Vue 3 を試す前に最初から最後まで読まなければならないものではありません。** Vue 3 を学ぶには、[新しいドキュメント](https://ja.vuejs.org)を読むのがおすすめです。
 
 <!-- VueMastery Start -->
 <script setup>
@@ -13,34 +13,34 @@ import VueMasteryWidget from '../VueMastery.vue'
 <VueMasteryWidget/>
 <!-- VueMastery End -->
 
-## Notable New Features
+## 注目すべき新機能
 
-Some of the new features to keep an eye on in Vue 3 include:
+Vue 3 で注目すべき新機能には、以下のようなものがあります:
 
 - [Composition API](https://ja.vuejs.org/guide/extras/composition-api-faq.html)<span class="note">\*</span>
-- [SFC Composition API Syntax Sugar (`<script setup>`)](https://ja.vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
+- [SFC Composition API のシンタックスシュガー（`<script setup>`）](https://ja.vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
 - [Teleport](https://ja.vuejs.org/guide/built-ins/teleport.html)
-- [Fragments](./new/fragments.html)
-- [Emits Component Option](https://ja.vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
-- [`createRenderer` API from `@vue/runtime-core`](https://ja.vuejs.org/api/custom-renderer.html) to create custom renderers
-- [SFC State-driven CSS Variables (`v-bind` in `<style>`)](https://ja.vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
-- [SFC `<style scoped>` can now include global rules or rules that target only slotted content](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0023-scoped-styles-changes.md)
-- [Suspense](https://ja.vuejs.org/guide/built-ins/suspense.html) <sup class="warning">experimental</sup>
+- [フラグメント](./new/fragments.html)
+- [コンポーネントオプション emits](https://ja.vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
+- カスタムレンダラーを作成するための [`createRenderer` API（`@vue/runtime-core` からエクスポート）](https://ja.vuejs.org/api/custom-renderer.html)
+- [SFC 状態駆動型 CSS 変数（`<style>` 内の `v-bind`）](https://ja.vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
+- [SFC `<style scoped>` にグローバルルールやスロットコンテンツのみを対象としたルールを含めることができるようになりました](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0023-scoped-styles-changes.md)
+- [Suspense](https://ja.vuejs.org/guide/built-ins/suspense.html) <sup class="warning">実験的な機能</sup>
 
-<sub class="note"><b>\*</b> Now also supported in <a href="https://blog.vuejs.org/posts/vue-2-7-naruto.html" target="_blank">Vue 2.7</a></sub><br>
-<sub class="note"><b>\*\*</b> Supported in Vue 2.7, but only for type inference</sub>
+<sub class="note"><b>\*</b> <a href="https://blog.vuejs.org/posts/vue-2-7-naruto.html" target="_blank">Vue 2.7</a> でもサポートされるようになりました</sub><br>
+<sub class="note"><b>\*\*</b> Vue 2.7 でサポートされますが、型推論のみがサポートされます</sub>
 
-## Breaking Changes
+## 破壊的変更
 
-Breaking changes between Vue 2 and Vue 3 are listed [here](./breaking-changes/).
+Vue 2 から Vue 3 の破壊的変更は[こちら](./breaking-changes/)に列挙されています。
 
-## New Framework-level Recommendations
+## フレームワークレベルでの新しい推奨事項
 
-New framework-level recommendations are listed [here](./recommendations).
+フレームワークレベルでの新しい推奨事項は[こちら](./recommendations)に列挙されています。
 
-## Migration Build
+## 移行ビルド
 
-If you have an existing Vue 2 project or library that you intend to upgrade to Vue 3, we provide a build of Vue 3 that offers Vue 2 compatible APIs. Check out the [Migration Build](./migration-build.html) page for more details.
+既存の Vue 2 プロジェクトやライブラリーをお持ちで、Vue 3 にアップグレードする予定がある場合、Vue 2 互換の API を提供する Vue 3 のビルドを提供します。詳しくは[移行ビルド](./migration-build.html)のページをご確認ください。
 
 <style>
 .note {

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -4,7 +4,7 @@
 Learn more about [Extended LTS](https://v2.vuejs.org/lts/) if upgrading to Vue 3 isn't feasible before the EOL date.
 :::
 
-This guide is primarily for users with prior Vue 2 experience who want to learn about the changes between Vue 2 and Vue 3. **This is not something you have to read from top to bottom before trying out Vue 3.** The recommended way to learn Vue 3 is by reading the [new documentation](https://vuejs.org).
+This guide is primarily for users with prior Vue 2 experience who want to learn about the changes between Vue 2 and Vue 3. **This is not something you have to read from top to bottom before trying out Vue 3.** The recommended way to learn Vue 3 is by reading the [new documentation](https://ja.vuejs.org).
 
 <!-- VueMastery Start -->
 <script setup>
@@ -17,15 +17,15 @@ import VueMasteryWidget from '../VueMastery.vue'
 
 Some of the new features to keep an eye on in Vue 3 include:
 
-- [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html)<span class="note">\*</span>
-- [SFC Composition API Syntax Sugar (`<script setup>`)](https://vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
-- [Teleport](https://vuejs.org/guide/built-ins/teleport.html)
+- [Composition API](https://ja.vuejs.org/guide/extras/composition-api-faq.html)<span class="note">\*</span>
+- [SFC Composition API Syntax Sugar (`<script setup>`)](https://ja.vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
+- [Teleport](https://ja.vuejs.org/guide/built-ins/teleport.html)
 - [Fragments](./new/fragments.html)
-- [Emits Component Option](https://vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
-- [`createRenderer` API from `@vue/runtime-core`](https://vuejs.org/api/custom-renderer.html) to create custom renderers
-- [SFC State-driven CSS Variables (`v-bind` in `<style>`)](https://vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
+- [Emits Component Option](https://ja.vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
+- [`createRenderer` API from `@vue/runtime-core`](https://ja.vuejs.org/api/custom-renderer.html) to create custom renderers
+- [SFC State-driven CSS Variables (`v-bind` in `<style>`)](https://ja.vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
 - [SFC `<style scoped>` can now include global rules or rules that target only slotted content](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0023-scoped-styles-changes.md)
-- [Suspense](https://vuejs.org/guide/built-ins/suspense.html) <sup class="warning">experimental</sup>
+- [Suspense](https://ja.vuejs.org/guide/built-ins/suspense.html) <sup class="warning">experimental</sup>
 
 <sub class="note"><b>\*</b> Now also supported in <a href="https://blog.vuejs.org/posts/vue-2-7-naruto.html" target="_blank">Vue 2.7</a></sub><br>
 <sub class="note"><b>\*\*</b> Supported in Vue 2.7, but only for type inference</sub>

--- a/src/ja/index.md
+++ b/src/ja/index.md
@@ -1,0 +1,49 @@
+# Vue 3 Migration Guide
+
+:::warning Vue 2 support will end on December 31st, 2023.
+Learn more about [Extended LTS](https://v2.vuejs.org/lts/) if upgrading to Vue 3 isn't feasible before the EOL date.
+:::
+
+This guide is primarily for users with prior Vue 2 experience who want to learn about the changes between Vue 2 and Vue 3. **This is not something you have to read from top to bottom before trying out Vue 3.** The recommended way to learn Vue 3 is by reading the [new documentation](https://vuejs.org).
+
+<!-- VueMastery Start -->
+<script setup>
+import VueMasteryWidget from '../VueMastery.vue'
+</script>
+<VueMasteryWidget/>
+<!-- VueMastery End -->
+
+## Notable New Features
+
+Some of the new features to keep an eye on in Vue 3 include:
+
+- [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html)<span class="note">\*</span>
+- [SFC Composition API Syntax Sugar (`<script setup>`)](https://vuejs.org/api/sfc-script-setup.html)<span class="note">\*</span>
+- [Teleport](https://vuejs.org/guide/built-ins/teleport.html)
+- [Fragments](./new/fragments.html)
+- [Emits Component Option](https://vuejs.org/api/options-state.html#emits)<span class="note">\*\*</span>
+- [`createRenderer` API from `@vue/runtime-core`](https://vuejs.org/api/custom-renderer.html) to create custom renderers
+- [SFC State-driven CSS Variables (`v-bind` in `<style>`)](https://vuejs.org/api/sfc-css-features.html#v-bind-in-css)<span class="note">\*</span>
+- [SFC `<style scoped>` can now include global rules or rules that target only slotted content](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0023-scoped-styles-changes.md)
+- [Suspense](https://vuejs.org/guide/built-ins/suspense.html) <sup class="warning">experimental</sup>
+
+<sub class="note"><b>\*</b> Now also supported in <a href="https://blog.vuejs.org/posts/vue-2-7-naruto.html" target="_blank">Vue 2.7</a></sub><br>
+<sub class="note"><b>\*\*</b> Supported in Vue 2.7, but only for type inference</sub>
+
+## Breaking Changes
+
+Breaking changes between Vue 2 and Vue 3 are listed [here](./breaking-changes/).
+
+## New Framework-level Recommendations
+
+New framework-level recommendations are listed [here](./recommendations).
+
+## Migration Build
+
+If you have an existing Vue 2 project or library that you intend to upgrade to Vue 3, we provide a build of Vue 3 that offers Vue 2 compatible APIs. Check out the [Migration Build](./migration-build.html) page for more details.
+
+<style>
+.note {
+  color: #476582;
+}
+</style>

--- a/src/ja/migration-build.md
+++ b/src/ja/migration-build.md
@@ -20,7 +20,7 @@ While we've tried hard to make the migration build mimic Vue 2 behavior as much 
 
 - Internet Explorer 11 support: [Vue 3 has officially dropped the plan for IE11 support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md). If you still need to support IE11 or below, you will have to stay on Vue 2.
 
-- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/core/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), it is probably better to wait for Nuxt 3.
+- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/core/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://ja.vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), it is probably better to wait for Nuxt 3.
 
 ### Expectations
 
@@ -46,7 +46,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
 
    - If using custom webpack setup: Upgrade `vue-loader` to `^16.0.0`.
    - If using `vue-cli`: upgrade to the latest `@vue/cli-service` with `vue upgrade`
-   - (Alternative) migrate to [Vite](https://vitejs.dev/) + [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2). [[Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/565b948919eb58f22a32afca7e321b490cb3b074)]
+   - (Alternative) migrate to [Vite](https://ja.vitejs.dev/) + [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2). [[Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/565b948919eb58f22a32afca7e321b490cb3b074)]
 
 2. In `package.json`, update `vue` to 3.1, install `@vue/compat` of the same version, and replace `vue-template-compiler` (if present) with `@vue/compiler-sfc`:
 
@@ -307,7 +307,7 @@ Features that start with `COMPILER_` are compiler-specific: if you are using the
 | GLOBAL_PROTOTYPE             | ✔    | `Vue.prototype` -> `app.config.globalProperties`                      | [link](./breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties) |
 | GLOBAL_SET                   | ✔    | `Vue.set` removed (no longer needed)                                  |                                                                                             |
 | GLOBAL_DELETE                | ✔    | `Vue.delete` removed (no longer needed)                               |                                                                                             |
-| GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` removed (use `reactive`)                             | [link](https://vuejs.org/api/reactivity-core.html#reactive)                                 |
+| GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` removed (use `reactive`)                             | [link](https://ja.vuejs.org/api/reactivity-core.html#reactive)                                 |
 | CONFIG_KEY_CODES             | ✔    | config.keyCodes removed                                               | [link](./breaking-changes/keycode-modifiers.html)                                            |
 | CONFIG_WHITESPACE            | ✔    | In Vue 3 whitespace defaults to `"condense"`                          |                                                                                             |
 | INSTANCE_SET                 | ✔    | `vm.$set` removed (no longer needed)                                  |                                                                                             |

--- a/src/ja/migration-build.md
+++ b/src/ja/migration-build.md
@@ -1,54 +1,54 @@
-# Migration Build
+# 移行ビルド
 
-## Overview
+## 概要
 
-`@vue/compat` (aka "the migration build") is a build of Vue 3 that provides configurable Vue 2 compatible behavior.
+`@vue/compat`（別名「移行ビルド」）は、設定可能な Vue 2 互換の動作を提供する、Vue 3 のビルドです。
 
-The migration build runs in Vue 2 mode by default - most public APIs behave exactly like Vue 2, with only a few exceptions. Usage of features that have changed or been deprecated in Vue 3 will emit runtime warnings. A feature's compatibility can also be enabled/disabled on a per-component basis.
+移行ビルドはデフォルトで Vue 2 モードで動作します。ほとんどの公開 API はいくつかの例外を除いて、Vue 2 とまったく同じように動作します。Vue 3 で変更または非推奨となった機能を使用すると、実行時警告が表示されます。機能の互換性はコンポーネント単位で有効化/無効化できます。
 
-### Intended Use Cases
+### 想定しているユースケース
 
-- Upgrading a Vue 2 application to Vue 3 (with [limitations](#known-limitations))
-- Migrating a library to support Vue 3
-- For experienced Vue 2 developers who have not tried Vue 3 yet, the migration build can be used in place of Vue 3 to help learn the difference between versions.
+- Vue 2 アプリケーションを Vue 3 にアップグレードする（[制限](#known-limitations)あり）
+- Vue 3 に対応するためのライブラリーの移行
+- Vue 3 をまだ試していない経験豊富な Vue 2 開発者にとって、Vue 3 の代わりに移行ビルドを使用することで、バージョン間の違いを学ぶことができます。
 
-### Known Limitations
+### 既知の制限
 
-While we've tried hard to make the migration build mimic Vue 2 behavior as much as possible, there are some limitations that may prevent your app from being eligible for upgrading:
+移行ビルドは Vue 2 の動作をできるだけ模倣するよう努力していますが、いくつかの制限があるため、アプリをアップグレードの対象にできない場合があります:
 
-- Dependencies that rely on Vue 2 internal APIs or undocumented behavior. The most common case is usage of private properties on `VNodes`. If your project relies on component libraries like [Vuetify](https://vuetifyjs.com/en/), [Quasar](https://quasar.dev/) or [ElementUI](https://element.eleme.io/#/en-US), it is best to wait for their Vue 3 compatible versions.
+- Vue 2 の内部 API やドキュメントにはない動作に依存する依存関係。最も一般的なケースは、`VNodes` のプライベートプロパティの使用です。あなたのプロジェクトが [Vuetify](https://vuetifyjs.com/en/), [Quasar](https://quasar.dev/), [ElementUI](https://element.eleme.io/#/en-US) のようなコンポーネントライブラリーに依存している場合、それらの Vue 3 互換バージョンを待つのが最善です。
 
-- Internet Explorer 11 support: [Vue 3 has officially dropped the plan for IE11 support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md). If you still need to support IE11 or below, you will have to stay on Vue 2.
+- Internet Explorer 11 対応: [Vue 3 は IE11 対応の計画を正式に取りやめました](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md)。まだ IE11 以下のサポートが必要な場合は、Vue 2 のままにしておく必要があります。
 
-- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/core/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://ja.vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), it is probably better to wait for Nuxt 3.
+- サーバーサイドレンダリング: 移行ビルドは SSR にも使えますが、カスタム SSR セットアップの移行はもっと複雑です。`vue-server-renderer` を [`@vue/server-renderer`](https://github.com/vuejs/core/tree/master/packages/server-renderer) に置き換えるのが一般的です。Vue 3 ではバンドルレンダラーが提供されなくなったので、Vue 3 の SSR を [Vite](https://ja.vitejs.dev/guide/ssr.html) で使用することが推奨されています。[Nuxt.js](https://nuxtjs.org/ja/) を使用している場合は、Nuxt 3 を待つ方がよいでしょう。
 
-### Expectations
+### 期待されること
 
-Please note that the migration build aims to cover only publicly documented Vue 2 APIs and behavior. If your application fails to run under the migration build due to reliance on undocumented behavior, it is unlikely that we'll tweak the migration build to cater to your specific case. Consider refactoring to remove reliance on the behavior in question instead.
+移行ビルドは、公開されている Vue 2 の API と動作のみをカバーすることを目的としていることにご注意ください。ドキュメントにはない動作に依存していることにより移行ビルドでアプリケーションが実行できない場合、その特定のケースに対応するために移行ビルドを調整することはまずありません。代わりに、問題のある動作への依存を取り除くためのリファクタリングを検討してください。
 
-A word of caution: if your application is large and complex, migration will likely be a challenge even with the migration build. If your app is unfortunately not suitable for upgrade, do note that we are planning to backport Composition API and some other Vue 3 features to the 2.7 release (estimated late Q3 2021).
+注意: アプリケーションが大規模で複雑な場合、移行ビルドを使用しても移行は困難である可能性が高いです。もしあなたのアプリが残念ながらアップグレードに適さない場合、Composition API と他のいくつかの Vue 3 機能を 2.7 リリースでバックポートする予定であることに注意してください（2021 年第 3 四半期後半に予定）。
 
-If you do get your app running on the migration build, you **can** ship it to production before the migration is complete. Although there is a small performance/size overhead, it should not noticeably affect production UX. You may have to do so when you have dependencies that rely on Vue 2 behavior, and cannot be upgraded/replaced.
+移行ビルドでアプリを動作させる場合でも、移行が完了する前にプロダクション環境へ出荷**できます**。パフォーマンスやサイズのオーバーヘッドが若干発生しますが、プロダクション環境の UX に顕著な影響を与えることはないでしょう。Vue 2 の動作に依存する依存関係があってアップグレードや置き換えができない場合は、そのようにする必要があるかもしれません。
 
-The migration build will be provided starting with 3.1, and will continue to be published alongside the 3.2 release line. We do plan to eventually stop publishing the migration build in a future minor version (no earlier than EOY 2021), so you should still aim to switch to the standard build before then.
+移行用ビルドは 3.1 から提供され、3.2 のリリースラインと同時に公開され続けます。将来のマイナーバージョン（2021 年末以降）で移行用ビルドの公開を終了する予定ですので、それまでに標準ビルドへの移行を目指す必要があります。
 
-## Upgrade Workflow
+## アップグレードのワークフロー
 
-The following workflow walks through the steps of migrating an actual Vue 2 app (Vue HackerNews 2.0) to Vue 3. The full commits can be found [here](https://github.com/vuejs/vue-hackernews-2.0/compare/migration). Note that the actual steps required for your project may vary, and these steps should be treated as general guidance rather than strict instructions.
+以下のワークフローでは、実際の Vue 2 アプリ（Vue HackerNews 2.0）を Vue 3 に移行するステップを説明します。完全なコミットは、[こちら](https://github.com/vuejs/vue-hackernews-2.0/compare/migration)で見ることができます。あなたのプロジェクトに必要な実際の手順は異なる可能性があり、これらの手順は厳密な指示ではなく、一般的なガイダンスとして扱われるべきであることに注意してください。
 
-### Preparations
+### 準備
 
-- If you are still using the [deprecated named / scoped slot syntax](https://v2.vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax), update it to the latest syntax first (which is already supported in 2.6).
+- 非推奨の[名前付き/スコープ付きスロット構文](https://jp.vuejs.org/v2/guide/components-slots.html#%E9%9D%9E%E6%8E%A8%E5%A5%A8%E3%81%AE%E6%A7%8B%E6%96%87)をまだ使用している場合は、まず最新の構文にアップデートしてください（2.6 ですでにサポートされています）。
 
-### Installation
+### インストール
 
-1. Upgrade tooling if applicable.
+1. 該当する場合はツールをアップグレードします。
 
-   - If using custom webpack setup: Upgrade `vue-loader` to `^16.0.0`.
-   - If using `vue-cli`: upgrade to the latest `@vue/cli-service` with `vue upgrade`
-   - (Alternative) migrate to [Vite](https://ja.vitejs.dev/) + [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2). [[Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/565b948919eb58f22a32afca7e321b490cb3b074)]
+   - カスタム webpack セットアップを使用している場合: `vue-loader` を `^16.0.0` にアップグレードしてください。
+   - `vue-cli` を使用している場合: `vue upgrade` を使って、最新の `@vue/cli-service` にアップグレードしてください
+   - （代替）[Vite](https://ja.vitejs.dev/) + [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2) に移行する。[[コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/565b948919eb58f22a32afca7e321b490cb3b074)]
 
-2. In `package.json`, update `vue` to 3.1, install `@vue/compat` of the same version, and replace `vue-template-compiler` (if present) with `@vue/compiler-sfc`:
+2. `package.json` で `vue` を 3.1 に更新し、同じバージョンの `@vue/compat` をインストールし、もし `vue-template-compiler` が存在すれば `@vue/compiler-sfc` で置き換えます:
 
    ```diff
    "dependencies": {
@@ -63,11 +63,11 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
    }
    ```
 
-   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/14f6f1879b43f8610add60342661bf915f5c4b20)
+   [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/14f6f1879b43f8610add60342661bf915f5c4b20)
 
-3. In the build setup, alias `vue` to `@vue/compat` and enable compat mode via Vue compiler options.
+3. ビルド設定で `vue` を `@vue/compat` にエイリアスし、Vue コンパイラーオプションで互換モードを有効にします。
 
-   **Example Configs**
+   **設定の例**
 
    <details>
      <summary><b>vue-cli</b></summary>
@@ -155,7 +155,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
 
    </details>
 
-4. If you are using TypeScript, you will also need to modify `vue`'s typing to expose the default export (which is no longer present in Vue 3) by adding a `*.d.ts` file with the following:
+4. TypeScript を使用している場合は、以下のように `*.d.ts` ファイルを追加して、（Vue 3 では存在しなくなった）デフォルトエクスポートを公開するよう `vue` の型付けを変更する必要があります:
 
    ```ts
    declare module 'vue' {
@@ -168,71 +168,71 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
    }
    ```
 
-5. At this point, your application may encounter some compile-time errors / warnings (e.g. use of filters). Fix them first. If all compiler warnings are gone, you can also set the compiler to Vue 3 mode.
+5. この時点で、アプリケーションはいくつかのコンパイル時のエラーや警告（例: フィルタの使用）に遭遇するかもしれません。まずそれらを修正します。すべてのコンパイラーの警告が消えたら、コンパイラーを Vue 3 モードに設定することもできます。
 
-   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/b05d9555f6e115dea7016d7e5a1a80e8f825be52)
+   [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/b05d9555f6e115dea7016d7e5a1a80e8f825be52)
 
-6. After fixing the errors, the app should be able to run if it is not subject to the [limitations](#known-limitations) mentioned above.
+6. エラーの修正後、上記の[制限](#known-limitations)に該当しなければ、アプリは実行できるはずです。
 
-   You will likely see a LOT of warnings from both the command line and the browser console. Here are some general tips:
+   コマンドラインとブラウザのコンソールの両方から、多くの警告が表示されるでしょう。ここでは、一般的なヒントをいくつか紹介します:
 
-   - You can filter for specific warnings in the browser console. It's a good idea to use the filter and focus on fixing one item at a time. You can also use negated filters like `-GLOBAL_MOUNT`.
+   - ブラウザコンソールで特定の警告をフィルタリングできます。フィルターを使い、一度に 1 つの項目を修正するのがよいでしょう。また、`-GLOBAL_MOUNT` のような否定的なフィルターも使用できます。
 
-   - You can suppress specific deprecations via [compat configuration](#compat-configuration).
+   - [互換性の設定](#compat-configuration)を使って、特定の非推奨を抑制できます。
 
-   - Some warnings may be caused by a dependency that you use (e.g. `vue-router`). You can check this from the warning's component trace or stack trace (expanded on click). Focus on fixing the warnings that originate from your own source code first.
+   - 一部の警告は、使用している依存関係（例: `vue-router`）が原因となっている場合があります。これは、警告のコンポーネントトレースやスタックトレース（クリックすると展開されます）から確認できます。まずは自分のソースコードに起因する警告を修正することに専念してください。
 
-   - If you are using `vue-router`, note `<transition>` and `<keep-alive>` will not work with `<router-view>` until you upgrade to `vue-router` v4.
+   - `vue-router` を使用している場合、`<transition>` と `<keep-alive>` は `vue-router` v4 にアップグレードするまで `<router-view>` で動作しないので注意してください。
 
-7. Update [`<transition>` class names](./breaking-changes/transition.html). This is the only feature that does not have a runtime warning. You can do a project-wide search for `.*-enter` and `.*-leave` CSS class names.
+7. [`<transition>` のクラス名](./breaking-changes/transition.html)を更新します。これは実行時の警告がない唯一の機能です。`.*-enter` と `.*-leave` の CSS クラス名をプロジェクト全体で検索できます。
 
-   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/d300103ba622ae26ac26a82cd688e0f70b6c1d8f)
+   [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/d300103ba622ae26ac26a82cd688e0f70b6c1d8f)
 
-8. Update app entry to use [new global mounting API](./breaking-changes/global-api.html#a-new-global-api-createapp).
+8. [新しいグローバルマウント API](./breaking-changes/global-api.html#a-new-global-api-createapp) を使用するようにアプリのエントリーを更新します。
 
-   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/a6e0c9ac7b1f4131908a4b1e43641f608593f714)
+   [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/a6e0c9ac7b1f4131908a4b1e43641f608593f714)
 
-9. [Upgrade `vuex` to v4](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html).
+9. [`vuex` を v4 にアップグレード](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html)します。
 
-   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/5bfd4c61ee50f358cd5daebaa584f2c3f91e0205)
+   [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/5bfd4c61ee50f358cd5daebaa584f2c3f91e0205)
 
-10. [Upgrade `vue-router` to v4](https://router.vuejs.org/index.html). If you also use `vuex-router-sync`, you can replace it with a store getter.
+10. [`vue-router` を v4 にアップグレード](https://router.vuejs.org/index.html)します。`vuex-router-sync` も使っている場合は、ストアゲッターに置き換えることができます。
 
-    After the upgrade, to use `<transition>` and `<keep-alive>` with `<router-view>` requires using the new [scoped-slot based syntax](https://router.vuejs.org/guide/migration/#router-view-keep-alive-and-transition).
+    アップグレード後、`<transition>` と `<keep-alive>` を `<router-view>` で使用するには、新しい[スコープ付きスロットベースの構文](https://router.vuejs.org/guide/migration/#router-view-keep-alive-and-transition)を使用する必要があります。
 
-    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/758961e73ac4089890079d4ce14996741cf9344b)
+    [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/758961e73ac4089890079d4ce14996741cf9344b)
 
-11. Pick off individual warnings. Note some features have conflicting behavior between Vue 2 and Vue 3 - for example, the render function API, or the functional component vs. async component change. To migrate to Vue 3 API without affecting the rest of the application, you can opt-in to Vue 3 behavior on a per-component basis with the [`compatConfig` option](#per-component-config).
+11. 個々の警告を取り除きます。一部の機能では、Vue 2 と Vue 3 との間で矛盾する動作があることに注意してください - 例えば、レンダー関数 API または関数型コンポーネントと非同期コンポーネントの変更などです。アプリケーションの残りの部分に影響を与えずに Vue 3 の API へ移行するには、[`compatConfig` オプション](#per-component-config)を使用してコンポーネントごとに Vue 3 の動作にオプトインできます。
 
-    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/d0c7d3ae789be71b8fd56ce79cb4cb1f921f893b)
+    [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/d0c7d3ae789be71b8fd56ce79cb4cb1f921f893b)
 
-12. When all warnings are fixed, you can remove the migration build and switch to Vue 3 proper. Note you may not be able to do so if you still have dependencies that rely on Vue 2 behavior.
+12. すべての警告が修正されたら、移行ビルドを削除して Vue 3 に正しく切り替えることができます。ただし、Vue 2 の動作に依存する依存関係が残っている場合は、切り替えができない可能性があることに注意してください。
 
-    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/9beb45490bc5f938c9e87b4ac1357cfb799565bd)
+    [コミットの例](https://github.com/vuejs/vue-hackernews-2.0/commit/9beb45490bc5f938c9e87b4ac1357cfb799565bd)
 
-## Compat Configuration
+## 互換性の設定 {#compat-configuration}
 
-### Global Config
+### グローバル設定
 
-Compat features can be disabled individually:
+互換機能は個別に無効化できます:
 
 ```js
 import { configureCompat } from 'vue'
 
-// disable compat for certain features
+// 特定の機能の互換性を無効化
 configureCompat({
   FEATURE_ID_A: false,
   FEATURE_ID_B: false
 })
 ```
 
-Alternatively, the entire application can default to Vue 3 behavior, with only certain compat features enabled:
+または、特定の互換機能のみを有効化し、アプリケーション全体はデフォルトで Vue 3 の動作にできます:
 
 ```js
 import { configureCompat } from 'vue'
 
-// default everything to Vue 3 behavior, and only enable compat
-// for certain features
+// デフォルトですべてを Vue 3 の動作にして、特定の機能の
+// 互換性のみを有効化
 configureCompat({
   MODE: 3,
   FEATURE_ID_A: true,
@@ -240,104 +240,104 @@ configureCompat({
 })
 ```
 
-### Per-Component Config
+### コンポーネントごとの設定
 
-A component can use the `compatConfig` option, which expects the same options as the global `configureCompat` method:
+コンポーネントで `compatConfig` オプションを使用できます。このオプションはグローバルの `configureCompat` メソッドと同じオプションを受け付けます:
 
 ```js
 export default {
   compatConfig: {
-    MODE: 3, // opt-in to Vue 3 behavior for this component only
-    FEATURE_ID_A: true // features can also be toggled at component level
+    MODE: 3, // このコンポーネントのみ Vue 3 の動作にオプトイン
+    FEATURE_ID_A: true // 機能はコンポーネントレベルでも切り替え可能
   }
   // ...
 }
 ```
 
-### Compiler-specific Config
+### コンパイラー固有の設定
 
-Features that start with `COMPILER_` are compiler-specific: if you are using the full build (with in-browser compiler), they can be configured at runtime. However if using a build setup, they must be configured via the `compilerOptions` in the build config instead (see example configs above).
+`COMPILER_` で始まる機能は、コンパイラー固有のものです。フルビルド（ブラウザ内コンパイラーつき）を使用している場合、実行時に設定できます。ただしビルドセットアップを使用している場合は、代わりにビルド設定の `compilerOptions` を使用して設定する必要があります（上記の設定例を参照）。
 
-## Feature Reference
+## 機能リファレンス
 
-### Compatibility Types
+### 互換性の種類
 
-- ✔ Fully compatible
-- ◐ Partially Compatible with caveats
-- ⨂ Incompatible (warning only)
-- ⭘ Compat only (no warning)
+- ✔ 完全に互換
+- ◐ 部分的な互換性（注意事項あり）
+- ⨂ 互換性なし（警告のみ）
+- ⭘ 互換性のみ（警告なし）
 
-### Incompatible
+### 互換性なし
 
-> Should be fixed upfront or will likely lead to errors
+> 事前に修正すべきで、そうしないとエラーが発生する可能性が高いです
 
 | ID                                    | Type | Description                                                             | Docs                                                                                       |
 | ------------------------------------- | ---- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| GLOBAL_MOUNT_CONTAINER                | ⨂    | Mounted application does not replace the element it's mounted to        | [link](./breaking-changes/mount-changes.html)                                               |
-| CONFIG_DEVTOOLS                       | ⨂    | production devtools is now a build-time flag                            | [link](https://github.com/vuejs/core/tree/master/packages/vue#bundler-build-feature-flags) |
-| COMPILER_V_IF_V_FOR_PRECEDENCE        | ⨂    | `v-if` and `v-for` precedence when used on the same element has changed | [link](./breaking-changes/v-if-v-for.html)                                                  |
-| COMPILER_V_IF_SAME_KEY                | ⨂    | `v-if` branches can no longer have the same key                         | [link](./breaking-changes/key-attribute.html#on-conditional-branches)                       |
-| COMPILER_V_FOR_TEMPLATE_KEY_PLACEMENT | ⨂    | `<template v-for>` key should now be placed on `<template>`             | [link](./breaking-changes/key-attribute.html#with-template-v-for)                           |
-| COMPILER_SFC_FUNCTIONAL               | ⨂    | `<template functional>` is no longer supported in SFCs                  | [link](./breaking-changes/functional-components.html#single-file-components-sfcs)           |
+| GLOBAL_MOUNT_CONTAINER                | ⨂    | マウントされたアプリケーションは、そこにマウントされている要素を置き換えません        | [link](./breaking-changes/mount-changes.html)                                               |
+| CONFIG_DEVTOOLS                       | ⨂    | production devtools はビルド時のフラグになりました                            | [link](https://github.com/vuejs/core/tree/master/packages/vue#bundler-build-feature-flags) |
+| COMPILER_V_IF_V_FOR_PRECEDENCE        | ⨂    | 同じ要素で使用した場合の `v-if` と `v-for` の優先順位は変更されました | [link](./breaking-changes/v-if-v-for.html)                                                  |
+| COMPILER_V_IF_SAME_KEY                | ⨂    | `v-if` のブランチは同じキーを持つことができなくなりました                         | [link](./breaking-changes/key-attribute.html#on-conditional-branches)                       |
+| COMPILER_V_FOR_TEMPLATE_KEY_PLACEMENT | ⨂    | `<template v-for>` のキーは `<template>` に配置するようになりました            | [link](./breaking-changes/key-attribute.html#with-template-v-for)                           |
+| COMPILER_SFC_FUNCTIONAL               | ⨂    | `<template functional>` は SFC でサポートされなくなりました                  | [link](./breaking-changes/functional-components.html#single-file-components-sfcs)           |
 
-### Partially Compatible with Caveats
+### 部分的な互換性（注意事項あり）
 
 | ID                       | Type | Description                                                                                                                                                                                | Docs                                                                                                           |
 | ------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| CONFIG_IGNORED_ELEMENTS  | ◐    | `config.ignoredElements` is now `config.compilerOptions.isCustomElement` (only in browser compiler build). If using build setup, `isCustomElement` must be passed via build configuration. | [link](./breaking-changes/global-api.html#config-ignoredelements-is-now-config-compileroptions-iscustomelement) |
-| COMPILER_INLINE_TEMPLATE | ◐    | `inline-template` removed (compat only supported in browser compiler build)                                                                                                                | [link](./breaking-changes/inline-template-attribute.html)                                                       |
-| PROPS_DEFAULT_THIS       | ◐    | props default factory no longer have access to `this` (in compat mode, `this` is not a real instance - it only exposes props, `$options` and injections)                                   | [link](./breaking-changes/props-default-this.html)                                                              |
-| INSTANCE_DESTROY         | ◐    | `$destroy` instance method removed (in compat mode, only supported on root instance)                                                                                                       |                                                                                                                |
-| GLOBAL_PRIVATE_UTIL      | ◐    | `Vue.util` is private and no longer available                                                                                                                                              |                                                                                                                |
-| CONFIG_PRODUCTION_TIP    | ◐    | `config.productionTip` no longer necessary                                                                                                                                                 | [link](./breaking-changes/global-api.html#config-productiontip-removed)                                         |
-| CONFIG_SILENT            | ◐    | `config.silent` removed                                                                                                                                                                    |                                                                                                                |
+| CONFIG_IGNORED_ELEMENTS  | ◐    | `config.ignoredElements` は `config.compilerOptions.isCustomElement` になりました（ブラウザコンパイラビルドのみ）。ビルドセットアップを使用している場合、`isCustomElement` はビルド設定で渡す必要があります。 | [link](./breaking-changes/global-api.html#config-ignoredelements-is-now-config-compileroptions-iscustomelement) |
+| COMPILER_INLINE_TEMPLATE | ◐    | `inline-template` は削除されました（ブラウザコンパイラビルドでのみ互換性がサポートされます）                                                                                                                | [link](./breaking-changes/inline-template-attribute.html)                                                       |
+| PROPS_DEFAULT_THIS       | ◐    | props の default ファクトリーは `this` にアクセスできなくなりました（互換モードでは、`this` は実際のインスタンスではありません - props, `$options` とインジェクションだけを公開します）                                   | [link](./breaking-changes/props-default-this.html)                                                              |
+| INSTANCE_DESTROY         | ◐    | インスタンスメソッド `$destroy` は削除されました（互換モードではルートインスタンスでのみサポート）                                                                                                       |                                                                                                                |
+| GLOBAL_PRIVATE_UTIL      | ◐    | `Vue.util` は非公開になり利用できなくなりました                                                                                                                                              |                                                                                                                |
+| CONFIG_PRODUCTION_TIP    | ◐    | `config.productionTip` は不要になりました                                                                                                                                                 | [link](./breaking-changes/global-api.html#config-productiontip-removed)                                         |
+| CONFIG_SILENT            | ◐    | `config.silent` は削除されました                                                                                                                                                                    |                                                                                                                |
 
-### Compat only (no warning)
+###  互換性のみ（警告なし）
 
 | ID                 | Type | Description                            | Docs                                      |
 | ------------------ | ---- | -------------------------------------- | ----------------------------------------- |
-| TRANSITION_CLASSES | ⭘    | Transition enter/leave classes changed | [link](./breaking-changes/transition.html) |
+| TRANSITION_CLASSES | ⭘    | トランジションの enter/leave クラスの変更 | [link](./breaking-changes/transition.html) |
 
-### Fully Compatible
+### 完全に互換
 
 | ID                           | Type | Description                                                           | Docs                                                                                        |
 | ---------------------------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | GLOBAL_MOUNT                 | ✔    | new Vue() -> createApp                                                | [link](./breaking-changes/global-api.html#mounting-app-instance)                             |
-| GLOBAL_EXTEND                | ✔    | Vue.extend removed (use `defineComponent` or `extends` option)        | [link](./breaking-changes/global-api.html#vue-extend-removed)                                |
+| GLOBAL_EXTEND                | ✔    | Vue.extend は削除されました（`defineComponent` か `extends` オプションを使用してください）        | [link](./breaking-changes/global-api.html#vue-extend-removed)                                |
 | GLOBAL_PROTOTYPE             | ✔    | `Vue.prototype` -> `app.config.globalProperties`                      | [link](./breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties) |
-| GLOBAL_SET                   | ✔    | `Vue.set` removed (no longer needed)                                  |                                                                                             |
-| GLOBAL_DELETE                | ✔    | `Vue.delete` removed (no longer needed)                               |                                                                                             |
-| GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` removed (use `reactive`)                             | [link](https://ja.vuejs.org/api/reactivity-core.html#reactive)                                 |
-| CONFIG_KEY_CODES             | ✔    | config.keyCodes removed                                               | [link](./breaking-changes/keycode-modifiers.html)                                            |
-| CONFIG_WHITESPACE            | ✔    | In Vue 3 whitespace defaults to `"condense"`                          |                                                                                             |
-| INSTANCE_SET                 | ✔    | `vm.$set` removed (no longer needed)                                  |                                                                                             |
-| INSTANCE_DELETE              | ✔    | `vm.$delete` removed (no longer needed)                               |                                                                                             |
-| INSTANCE_EVENT_EMITTER       | ✔    | `vm.$on`, `vm.$off`, `vm.$once` removed                               | [link](./breaking-changes/events-api.html)                                                   |
-| INSTANCE_EVENT_HOOKS         | ✔    | Instance no longer emits `hook:x` events                              | [link](./breaking-changes/vnode-lifecycle-events.html)                                       |
-| INSTANCE_CHILDREN            | ✔    | `vm.$children` removed                                                | [link](./breaking-changes/children.html)                                                     |
-| INSTANCE_LISTENERS           | ✔    | `vm.$listeners` removed                                               | [link](./breaking-changes/listeners-removed.html)                                            |
-| INSTANCE_SCOPED_SLOTS        | ✔    | `vm.$scopedSlots` removed; `vm.$slots` now exposes functions          | [link](./breaking-changes/slots-unification.html)                                            |
-| INSTANCE_ATTRS_CLASS_STYLE   | ✔    | `$attrs` now includes `class` and `style`                             | [link](./breaking-changes/attrs-includes-class-style.html)                                   |
-| OPTIONS_DATA_FN              | ✔    | `data` must be a function in all cases                                | [link](./breaking-changes/data-option.html)                                                  |
-| OPTIONS_DATA_MERGE           | ✔    | `data` from mixin or extension is now shallow merged                  | [link](./breaking-changes/data-option.html)                                                  |
+| GLOBAL_SET                   | ✔    | `Vue.set` は削除されました（不要になりました）                                  |                                                                                             |
+| GLOBAL_DELETE                | ✔    | `Vue.delete` は削除されました（不要になりました）                               |                                                                                             |
+| GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` は削除されました（`reactive` を使用してください）                             | [link](https://ja.vuejs.org/api/reactivity-core.html#reactive)                                 |
+| CONFIG_KEY_CODES             | ✔    | config.keyCodes は削除されました                                               | [link](./breaking-changes/keycode-modifiers.html)                                            |
+| CONFIG_WHITESPACE            | ✔    | Vue 3 では空白のデフォルトは `"condense"` です                          |                                                                                             |
+| INSTANCE_SET                 | ✔    | `vm.$set` は削除されました（不要になりました）                                  |                                                                                             |
+| INSTANCE_DELETE              | ✔    | `vm.$delete` は削除されました（不要になりました）                               |                                                                                             |
+| INSTANCE_EVENT_EMITTER       | ✔    | `vm.$on`, `vm.$off`, `vm.$once` は削除されました                               | [link](./breaking-changes/events-api.html)                                                   |
+| INSTANCE_EVENT_HOOKS         | ✔    | インスタンスは `hook:x` イベントを発行しなくなりました                              | [link](./breaking-changes/vnode-lifecycle-events.html)                                       |
+| INSTANCE_CHILDREN            | ✔    | `vm.$children` は削除されました                                                | [link](./breaking-changes/children.html)                                                     |
+| INSTANCE_LISTENERS           | ✔    | `vm.$listeners` は削除されました                                               | [link](./breaking-changes/listeners-removed.html)                                            |
+| INSTANCE_SCOPED_SLOTS        | ✔    | `vm.$scopedSlots` は削除されました。`vm.$slots` は関数を公開するようになりました          | [link](./breaking-changes/slots-unification.html)                                            |
+| INSTANCE_ATTRS_CLASS_STYLE   | ✔    | `$attrs` に `class` と `style` が含まれるようになりました                             | [link](./breaking-changes/attrs-includes-class-style.html)                                   |
+| OPTIONS_DATA_FN              | ✔    | `data` はどんな場合でも関数にする必要があります                                | [link](./breaking-changes/data-option.html)                                                  |
+| OPTIONS_DATA_MERGE           | ✔    | mixins や extends からの `data` は浅いマージになりました                  | [link](./breaking-changes/data-option.html)                                                  |
 | OPTIONS_BEFORE_DESTROY       | ✔    | `beforeDestroy` -> `beforeUnmount`                                    |                                                                                             |
 | OPTIONS_DESTROYED            | ✔    | `destroyed` -> `unmounted`                                            |                                                                                             |
-| WATCH_ARRAY                  | ✔    | watching an array no longer triggers on mutation unless deep          | [link](./breaking-changes/watch.html)                                                        |
-| V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` no longer supports keyCode modifiers                           | [link](./breaking-changes/keycode-modifiers.html)                                            |
-| CUSTOM_DIR                   | ✔    | Custom directive hook names changed                                   | [link](./breaking-changes/custom-directives.html)                                            |
-| ATTR_FALSE_VALUE             | ✔    | No longer removes attribute if binding value is boolean `false`       | [link](./breaking-changes/attribute-coercion.html)                                           |
-| ATTR_ENUMERATED_COERCION     | ✔    | No longer special case enumerated attributes                          | [link](./breaking-changes/attribute-coercion.html)                                           |
-| TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` no longer renders a root element by default      | [link](./breaking-changes/transition-group.html)                                             |
-| COMPONENT_ASYNC              | ✔    | Async component API changed (now requires `defineAsyncComponent`)     | [link](./breaking-changes/async-components.html)                                             |
-| COMPONENT_FUNCTIONAL         | ✔    | Functional component API changed (now must be plain functions)        | [link](./breaking-changes/functional-components.html)                                        |
-| COMPONENT_V_MODEL            | ✔    | Component v-model reworked                                            | [link](./breaking-changes/v-model.html)                                                      |
-| RENDER_FUNCTION              | ✔    | Render function API changed                                           | [link](./breaking-changes/render-function-api.html)                                          |
-| FILTERS                      | ✔    | Filters removed (this option affects only runtime filter APIs)        | [link](./breaking-changes/filters.html)                                                      |
-| COMPILER_IS_ON_ELEMENT       | ✔    | `is` usage is now restricted to `<component>` only                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
-| COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` replaced by `v-model` with arguments                    | [link](./breaking-changes/v-model.html)                                                      |
-| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` modifier removed                                        |                                                                                             |
-| COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` is now order sensitive                              | [link](./breaking-changes/v-bind.html)                                                       |
-| COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` modifier removed                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
-| COMPILER_V_FOR_REF           | ✔    | `ref` in `v-for` (compiler support)                                   |                                                                                             |
-| COMPILER_NATIVE_TEMPLATE     | ✔    | `<template>` with no special directives now renders as native element |                                                                                             |
-| COMPILER_FILTERS             | ✔    | filters (compiler support)                                            |                                                                                             |
+| WATCH_ARRAY                  | ✔    | 配列の監視をする際、deep でなければ配列の変更でトリガーされなくなりました          | [link](./breaking-changes/watch.html)                                                        |
+| V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` は keyCode 修飾子をサポートしなくなりました                           | [link](./breaking-changes/keycode-modifiers.html)                                            |
+| CUSTOM_DIR                   | ✔    | カスタムディレクティブのフック名が変更されました                                   | [link](./breaking-changes/custom-directives.html)                                            |
+| ATTR_FALSE_VALUE             | ✔    | バインドしている値が `false` でも、属性は削除されなくなりました       | [link](./breaking-changes/attribute-coercion.html)                                           |
+| ATTR_ENUMERATED_COERCION     | ✔    | 列挙型属性の特殊ケースは廃止                          | [link](./breaking-changes/attribute-coercion.html)                                           |
+| TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` はデフォルトではルート要素をレンダリングしなくなりました      | [link](./breaking-changes/transition-group.html)                                             |
+| COMPONENT_ASYNC              | ✔    | 非同期コンポーネントの API 変更（`defineAsyncComponent` が必要になりました）     | [link](./breaking-changes/async-components.html)                                             |
+| COMPONENT_FUNCTIONAL         | ✔    | 関数型コンポーネントの API 変更（普通の関数にする必要があります）        | [link](./breaking-changes/functional-components.html)                                        |
+| COMPONENT_V_MODEL            | ✔    | コンポーネントの v-model 改訂                                            | [link](./breaking-changes/v-model.html)                                                      |
+| RENDER_FUNCTION              | ✔    | レンダー関数の API 変更                                           | [link](./breaking-changes/render-function-api.html)                                          |
+| FILTERS                      | ✔    | フィルターは削除されました（このオプションは実行時のフィルター API のみに影響）        | [link](./breaking-changes/filters.html)                                                      |
+| COMPILER_IS_ON_ELEMENT       | ✔    | `is` の使用は `<component>` のみに制限されました                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
+| COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` は引数つきの `v-model` に置き換わりました                    | [link](./breaking-changes/v-model.html)                                                      |
+| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` 修飾子は削除されました                                        |                                                                                             |
+| COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` は順序に依存するようになりました                              | [link](./breaking-changes/v-bind.html)                                                       |
+| COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` 修飾子は削除されました                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
+| COMPILER_V_FOR_REF           | ✔    | `v-for` 内の `ref`（コンパイラーサポート）                                   |                                                                                             |
+| COMPILER_NATIVE_TEMPLATE     | ✔    | 特別なディレクティブなしの `<template>` は、ネイティブ要素としてレンダリングされるようになりました |                                                                                             |
+| COMPILER_FILTERS             | ✔    | フィルター（コンパイラーサポート）                                            |                                                                                             |

--- a/src/ja/migration-build.md
+++ b/src/ja/migration-build.md
@@ -1,0 +1,343 @@
+# Migration Build
+
+## Overview
+
+`@vue/compat` (aka "the migration build") is a build of Vue 3 that provides configurable Vue 2 compatible behavior.
+
+The migration build runs in Vue 2 mode by default - most public APIs behave exactly like Vue 2, with only a few exceptions. Usage of features that have changed or been deprecated in Vue 3 will emit runtime warnings. A feature's compatibility can also be enabled/disabled on a per-component basis.
+
+### Intended Use Cases
+
+- Upgrading a Vue 2 application to Vue 3 (with [limitations](#known-limitations))
+- Migrating a library to support Vue 3
+- For experienced Vue 2 developers who have not tried Vue 3 yet, the migration build can be used in place of Vue 3 to help learn the difference between versions.
+
+### Known Limitations
+
+While we've tried hard to make the migration build mimic Vue 2 behavior as much as possible, there are some limitations that may prevent your app from being eligible for upgrading:
+
+- Dependencies that rely on Vue 2 internal APIs or undocumented behavior. The most common case is usage of private properties on `VNodes`. If your project relies on component libraries like [Vuetify](https://vuetifyjs.com/en/), [Quasar](https://quasar.dev/) or [ElementUI](https://element.eleme.io/#/en-US), it is best to wait for their Vue 3 compatible versions.
+
+- Internet Explorer 11 support: [Vue 3 has officially dropped the plan for IE11 support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md). If you still need to support IE11 or below, you will have to stay on Vue 2.
+
+- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/core/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), it is probably better to wait for Nuxt 3.
+
+### Expectations
+
+Please note that the migration build aims to cover only publicly documented Vue 2 APIs and behavior. If your application fails to run under the migration build due to reliance on undocumented behavior, it is unlikely that we'll tweak the migration build to cater to your specific case. Consider refactoring to remove reliance on the behavior in question instead.
+
+A word of caution: if your application is large and complex, migration will likely be a challenge even with the migration build. If your app is unfortunately not suitable for upgrade, do note that we are planning to backport Composition API and some other Vue 3 features to the 2.7 release (estimated late Q3 2021).
+
+If you do get your app running on the migration build, you **can** ship it to production before the migration is complete. Although there is a small performance/size overhead, it should not noticeably affect production UX. You may have to do so when you have dependencies that rely on Vue 2 behavior, and cannot be upgraded/replaced.
+
+The migration build will be provided starting with 3.1, and will continue to be published alongside the 3.2 release line. We do plan to eventually stop publishing the migration build in a future minor version (no earlier than EOY 2021), so you should still aim to switch to the standard build before then.
+
+## Upgrade Workflow
+
+The following workflow walks through the steps of migrating an actual Vue 2 app (Vue HackerNews 2.0) to Vue 3. The full commits can be found [here](https://github.com/vuejs/vue-hackernews-2.0/compare/migration). Note that the actual steps required for your project may vary, and these steps should be treated as general guidance rather than strict instructions.
+
+### Preparations
+
+- If you are still using the [deprecated named / scoped slot syntax](https://v2.vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax), update it to the latest syntax first (which is already supported in 2.6).
+
+### Installation
+
+1. Upgrade tooling if applicable.
+
+   - If using custom webpack setup: Upgrade `vue-loader` to `^16.0.0`.
+   - If using `vue-cli`: upgrade to the latest `@vue/cli-service` with `vue upgrade`
+   - (Alternative) migrate to [Vite](https://vitejs.dev/) + [vite-plugin-vue2](https://github.com/underfin/vite-plugin-vue2). [[Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/565b948919eb58f22a32afca7e321b490cb3b074)]
+
+2. In `package.json`, update `vue` to 3.1, install `@vue/compat` of the same version, and replace `vue-template-compiler` (if present) with `@vue/compiler-sfc`:
+
+   ```diff
+   "dependencies": {
+   -  "vue": "^2.6.12",
+   +  "vue": "^3.1.0",
+   +  "@vue/compat": "^3.1.0"
+      ...
+   },
+   "devDependencies": {
+   -  "vue-template-compiler": "^2.6.12"
+   +  "@vue/compiler-sfc": "^3.1.0"
+   }
+   ```
+
+   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/14f6f1879b43f8610add60342661bf915f5c4b20)
+
+3. In the build setup, alias `vue` to `@vue/compat` and enable compat mode via Vue compiler options.
+
+   **Example Configs**
+
+   <details>
+     <summary><b>vue-cli</b></summary>
+
+   ```js
+   // vue.config.js
+   module.exports = {
+     chainWebpack: (config) => {
+       config.resolve.alias.set('vue', '@vue/compat')
+
+       config.module
+         .rule('vue')
+         .use('vue-loader')
+         .tap((options) => {
+           return {
+             ...options,
+             compilerOptions: {
+               compatConfig: {
+                 MODE: 2
+               }
+             }
+           }
+         })
+     }
+   }
+   ```
+
+   </details>
+
+   <details>
+     <summary><b>Plain webpack</b></summary>
+
+   ```js
+   // webpack.config.js
+   module.exports = {
+     resolve: {
+       alias: {
+         vue: '@vue/compat'
+       }
+     },
+     module: {
+       rules: [
+         {
+           test: /\.vue$/,
+           loader: 'vue-loader',
+           options: {
+             compilerOptions: {
+               compatConfig: {
+                 MODE: 2
+               }
+             }
+           }
+         }
+       ]
+     }
+   }
+   ```
+
+   </details>
+
+   <details>
+     <summary><b>Vite</b></summary>
+
+   ```js
+   // vite.config.js
+   export default {
+     resolve: {
+       alias: {
+         vue: '@vue/compat'
+       }
+     },
+     plugins: [
+       vue({
+         template: {
+           compilerOptions: {
+             compatConfig: {
+               MODE: 2
+             }
+           }
+         }
+       })
+     ]
+   }
+   ```
+
+   </details>
+
+4. If you are using TypeScript, you will also need to modify `vue`'s typing to expose the default export (which is no longer present in Vue 3) by adding a `*.d.ts` file with the following:
+
+   ```ts
+   declare module 'vue' {
+     import { CompatVue } from '@vue/runtime-dom'
+     const Vue: CompatVue
+     export default Vue
+     export * from '@vue/runtime-dom'
+     const { configureCompat } = Vue
+     export { configureCompat }
+   }
+   ```
+
+5. At this point, your application may encounter some compile-time errors / warnings (e.g. use of filters). Fix them first. If all compiler warnings are gone, you can also set the compiler to Vue 3 mode.
+
+   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/b05d9555f6e115dea7016d7e5a1a80e8f825be52)
+
+6. After fixing the errors, the app should be able to run if it is not subject to the [limitations](#known-limitations) mentioned above.
+
+   You will likely see a LOT of warnings from both the command line and the browser console. Here are some general tips:
+
+   - You can filter for specific warnings in the browser console. It's a good idea to use the filter and focus on fixing one item at a time. You can also use negated filters like `-GLOBAL_MOUNT`.
+
+   - You can suppress specific deprecations via [compat configuration](#compat-configuration).
+
+   - Some warnings may be caused by a dependency that you use (e.g. `vue-router`). You can check this from the warning's component trace or stack trace (expanded on click). Focus on fixing the warnings that originate from your own source code first.
+
+   - If you are using `vue-router`, note `<transition>` and `<keep-alive>` will not work with `<router-view>` until you upgrade to `vue-router` v4.
+
+7. Update [`<transition>` class names](./breaking-changes/transition.html). This is the only feature that does not have a runtime warning. You can do a project-wide search for `.*-enter` and `.*-leave` CSS class names.
+
+   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/d300103ba622ae26ac26a82cd688e0f70b6c1d8f)
+
+8. Update app entry to use [new global mounting API](./breaking-changes/global-api.html#a-new-global-api-createapp).
+
+   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/a6e0c9ac7b1f4131908a4b1e43641f608593f714)
+
+9. [Upgrade `vuex` to v4](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html).
+
+   [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/5bfd4c61ee50f358cd5daebaa584f2c3f91e0205)
+
+10. [Upgrade `vue-router` to v4](https://router.vuejs.org/index.html). If you also use `vuex-router-sync`, you can replace it with a store getter.
+
+    After the upgrade, to use `<transition>` and `<keep-alive>` with `<router-view>` requires using the new [scoped-slot based syntax](https://router.vuejs.org/guide/migration/#router-view-keep-alive-and-transition).
+
+    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/758961e73ac4089890079d4ce14996741cf9344b)
+
+11. Pick off individual warnings. Note some features have conflicting behavior between Vue 2 and Vue 3 - for example, the render function API, or the functional component vs. async component change. To migrate to Vue 3 API without affecting the rest of the application, you can opt-in to Vue 3 behavior on a per-component basis with the [`compatConfig` option](#per-component-config).
+
+    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/d0c7d3ae789be71b8fd56ce79cb4cb1f921f893b)
+
+12. When all warnings are fixed, you can remove the migration build and switch to Vue 3 proper. Note you may not be able to do so if you still have dependencies that rely on Vue 2 behavior.
+
+    [Example commit](https://github.com/vuejs/vue-hackernews-2.0/commit/9beb45490bc5f938c9e87b4ac1357cfb799565bd)
+
+## Compat Configuration
+
+### Global Config
+
+Compat features can be disabled individually:
+
+```js
+import { configureCompat } from 'vue'
+
+// disable compat for certain features
+configureCompat({
+  FEATURE_ID_A: false,
+  FEATURE_ID_B: false
+})
+```
+
+Alternatively, the entire application can default to Vue 3 behavior, with only certain compat features enabled:
+
+```js
+import { configureCompat } from 'vue'
+
+// default everything to Vue 3 behavior, and only enable compat
+// for certain features
+configureCompat({
+  MODE: 3,
+  FEATURE_ID_A: true,
+  FEATURE_ID_B: true
+})
+```
+
+### Per-Component Config
+
+A component can use the `compatConfig` option, which expects the same options as the global `configureCompat` method:
+
+```js
+export default {
+  compatConfig: {
+    MODE: 3, // opt-in to Vue 3 behavior for this component only
+    FEATURE_ID_A: true // features can also be toggled at component level
+  }
+  // ...
+}
+```
+
+### Compiler-specific Config
+
+Features that start with `COMPILER_` are compiler-specific: if you are using the full build (with in-browser compiler), they can be configured at runtime. However if using a build setup, they must be configured via the `compilerOptions` in the build config instead (see example configs above).
+
+## Feature Reference
+
+### Compatibility Types
+
+- ✔ Fully compatible
+- ◐ Partially Compatible with caveats
+- ⨂ Incompatible (warning only)
+- ⭘ Compat only (no warning)
+
+### Incompatible
+
+> Should be fixed upfront or will likely lead to errors
+
+| ID                                    | Type | Description                                                             | Docs                                                                                       |
+| ------------------------------------- | ---- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| GLOBAL_MOUNT_CONTAINER                | ⨂    | Mounted application does not replace the element it's mounted to        | [link](./breaking-changes/mount-changes.html)                                               |
+| CONFIG_DEVTOOLS                       | ⨂    | production devtools is now a build-time flag                            | [link](https://github.com/vuejs/core/tree/master/packages/vue#bundler-build-feature-flags) |
+| COMPILER_V_IF_V_FOR_PRECEDENCE        | ⨂    | `v-if` and `v-for` precedence when used on the same element has changed | [link](./breaking-changes/v-if-v-for.html)                                                  |
+| COMPILER_V_IF_SAME_KEY                | ⨂    | `v-if` branches can no longer have the same key                         | [link](./breaking-changes/key-attribute.html#on-conditional-branches)                       |
+| COMPILER_V_FOR_TEMPLATE_KEY_PLACEMENT | ⨂    | `<template v-for>` key should now be placed on `<template>`             | [link](./breaking-changes/key-attribute.html#with-template-v-for)                           |
+| COMPILER_SFC_FUNCTIONAL               | ⨂    | `<template functional>` is no longer supported in SFCs                  | [link](./breaking-changes/functional-components.html#single-file-components-sfcs)           |
+
+### Partially Compatible with Caveats
+
+| ID                       | Type | Description                                                                                                                                                                                | Docs                                                                                                           |
+| ------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| CONFIG_IGNORED_ELEMENTS  | ◐    | `config.ignoredElements` is now `config.compilerOptions.isCustomElement` (only in browser compiler build). If using build setup, `isCustomElement` must be passed via build configuration. | [link](./breaking-changes/global-api.html#config-ignoredelements-is-now-config-compileroptions-iscustomelement) |
+| COMPILER_INLINE_TEMPLATE | ◐    | `inline-template` removed (compat only supported in browser compiler build)                                                                                                                | [link](./breaking-changes/inline-template-attribute.html)                                                       |
+| PROPS_DEFAULT_THIS       | ◐    | props default factory no longer have access to `this` (in compat mode, `this` is not a real instance - it only exposes props, `$options` and injections)                                   | [link](./breaking-changes/props-default-this.html)                                                              |
+| INSTANCE_DESTROY         | ◐    | `$destroy` instance method removed (in compat mode, only supported on root instance)                                                                                                       |                                                                                                                |
+| GLOBAL_PRIVATE_UTIL      | ◐    | `Vue.util` is private and no longer available                                                                                                                                              |                                                                                                                |
+| CONFIG_PRODUCTION_TIP    | ◐    | `config.productionTip` no longer necessary                                                                                                                                                 | [link](./breaking-changes/global-api.html#config-productiontip-removed)                                         |
+| CONFIG_SILENT            | ◐    | `config.silent` removed                                                                                                                                                                    |                                                                                                                |
+
+### Compat only (no warning)
+
+| ID                 | Type | Description                            | Docs                                      |
+| ------------------ | ---- | -------------------------------------- | ----------------------------------------- |
+| TRANSITION_CLASSES | ⭘    | Transition enter/leave classes changed | [link](./breaking-changes/transition.html) |
+
+### Fully Compatible
+
+| ID                           | Type | Description                                                           | Docs                                                                                        |
+| ---------------------------- | ---- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| GLOBAL_MOUNT                 | ✔    | new Vue() -> createApp                                                | [link](./breaking-changes/global-api.html#mounting-app-instance)                             |
+| GLOBAL_EXTEND                | ✔    | Vue.extend removed (use `defineComponent` or `extends` option)        | [link](./breaking-changes/global-api.html#vue-extend-removed)                                |
+| GLOBAL_PROTOTYPE             | ✔    | `Vue.prototype` -> `app.config.globalProperties`                      | [link](./breaking-changes/global-api.html#vue-prototype-replaced-by-config-globalproperties) |
+| GLOBAL_SET                   | ✔    | `Vue.set` removed (no longer needed)                                  |                                                                                             |
+| GLOBAL_DELETE                | ✔    | `Vue.delete` removed (no longer needed)                               |                                                                                             |
+| GLOBAL_OBSERVABLE            | ✔    | `Vue.observable` removed (use `reactive`)                             | [link](https://vuejs.org/api/reactivity-core.html#reactive)                                 |
+| CONFIG_KEY_CODES             | ✔    | config.keyCodes removed                                               | [link](./breaking-changes/keycode-modifiers.html)                                            |
+| CONFIG_WHITESPACE            | ✔    | In Vue 3 whitespace defaults to `"condense"`                          |                                                                                             |
+| INSTANCE_SET                 | ✔    | `vm.$set` removed (no longer needed)                                  |                                                                                             |
+| INSTANCE_DELETE              | ✔    | `vm.$delete` removed (no longer needed)                               |                                                                                             |
+| INSTANCE_EVENT_EMITTER       | ✔    | `vm.$on`, `vm.$off`, `vm.$once` removed                               | [link](./breaking-changes/events-api.html)                                                   |
+| INSTANCE_EVENT_HOOKS         | ✔    | Instance no longer emits `hook:x` events                              | [link](./breaking-changes/vnode-lifecycle-events.html)                                       |
+| INSTANCE_CHILDREN            | ✔    | `vm.$children` removed                                                | [link](./breaking-changes/children.html)                                                     |
+| INSTANCE_LISTENERS           | ✔    | `vm.$listeners` removed                                               | [link](./breaking-changes/listeners-removed.html)                                            |
+| INSTANCE_SCOPED_SLOTS        | ✔    | `vm.$scopedSlots` removed; `vm.$slots` now exposes functions          | [link](./breaking-changes/slots-unification.html)                                            |
+| INSTANCE_ATTRS_CLASS_STYLE   | ✔    | `$attrs` now includes `class` and `style`                             | [link](./breaking-changes/attrs-includes-class-style.html)                                   |
+| OPTIONS_DATA_FN              | ✔    | `data` must be a function in all cases                                | [link](./breaking-changes/data-option.html)                                                  |
+| OPTIONS_DATA_MERGE           | ✔    | `data` from mixin or extension is now shallow merged                  | [link](./breaking-changes/data-option.html)                                                  |
+| OPTIONS_BEFORE_DESTROY       | ✔    | `beforeDestroy` -> `beforeUnmount`                                    |                                                                                             |
+| OPTIONS_DESTROYED            | ✔    | `destroyed` -> `unmounted`                                            |                                                                                             |
+| WATCH_ARRAY                  | ✔    | watching an array no longer triggers on mutation unless deep          | [link](./breaking-changes/watch.html)                                                        |
+| V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` no longer supports keyCode modifiers                           | [link](./breaking-changes/keycode-modifiers.html)                                            |
+| CUSTOM_DIR                   | ✔    | Custom directive hook names changed                                   | [link](./breaking-changes/custom-directives.html)                                            |
+| ATTR_FALSE_VALUE             | ✔    | No longer removes attribute if binding value is boolean `false`       | [link](./breaking-changes/attribute-coercion.html)                                           |
+| ATTR_ENUMERATED_COERCION     | ✔    | No longer special case enumerated attributes                          | [link](./breaking-changes/attribute-coercion.html)                                           |
+| TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` no longer renders a root element by default      | [link](./breaking-changes/transition-group.html)                                             |
+| COMPONENT_ASYNC              | ✔    | Async component API changed (now requires `defineAsyncComponent`)     | [link](./breaking-changes/async-components.html)                                             |
+| COMPONENT_FUNCTIONAL         | ✔    | Functional component API changed (now must be plain functions)        | [link](./breaking-changes/functional-components.html)                                        |
+| COMPONENT_V_MODEL            | ✔    | Component v-model reworked                                            | [link](./breaking-changes/v-model.html)                                                      |
+| RENDER_FUNCTION              | ✔    | Render function API changed                                           | [link](./breaking-changes/render-function-api.html)                                          |
+| FILTERS                      | ✔    | Filters removed (this option affects only runtime filter APIs)        | [link](./breaking-changes/filters.html)                                                      |
+| COMPILER_IS_ON_ELEMENT       | ✔    | `is` usage is now restricted to `<component>` only                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
+| COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` replaced by `v-model` with arguments                    | [link](./breaking-changes/v-model.html)                                                      |
+| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` modifier removed                                        |                                                                                             |
+| COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` is now order sensitive                              | [link](./breaking-changes/v-bind.html)                                                       |
+| COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` modifier removed                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
+| COMPILER_V_FOR_REF           | ✔    | `ref` in `v-for` (compiler support)                                   |                                                                                             |
+| COMPILER_NATIVE_TEMPLATE     | ✔    | `<template>` with no special directives now renders as native element |                                                                                             |
+| COMPILER_FILTERS             | ✔    | filters (compiler support)                                            |                                                                                             |

--- a/src/ja/new/fragments.md
+++ b/src/ja/new/fragments.md
@@ -1,0 +1,40 @@
+---
+badges:
+  - new
+---
+
+# Fragments <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+In Vue 3, components now have official support for multi-root node components, i.e., fragments!
+
+## 2.x Syntax
+
+In 2.x, multi-root components were not supported and would emit a warning when a user accidentally created one. As a result, many components are wrapped in a single `<div>` in order to fix this error.
+
+```html
+<!-- Layout.vue -->
+<template>
+  <div>
+    <header>...</header>
+    <main>...</main>
+    <footer>...</footer>
+  </div>
+</template>
+```
+
+## 3.x Syntax
+
+In 3.x, components now can have multiple root nodes! However, this does require developers to explicitly define where attributes should be distributed.
+
+```html
+<!-- Layout.vue -->
+<template>
+  <header>...</header>
+  <main v-bind="$attrs">...</main>
+  <footer>...</footer>
+</template>
+```
+
+For more information on how attribute inheritance works, see [Fallthrough Attributes](https://vuejs.org/guide/components/attrs.html#fallthrough-attributes).

--- a/src/ja/new/fragments.md
+++ b/src/ja/new/fragments.md
@@ -37,4 +37,4 @@ In 3.x, components now can have multiple root nodes! However, this does require 
 </template>
 ```
 
-For more information on how attribute inheritance works, see [Fallthrough Attributes](https://vuejs.org/guide/components/attrs.html#fallthrough-attributes).
+For more information on how attribute inheritance works, see [Fallthrough Attributes](https://ja.vuejs.org/guide/components/attrs.html#fallthrough-attributes).

--- a/src/ja/new/fragments.md
+++ b/src/ja/new/fragments.md
@@ -5,7 +5,7 @@ badges:
 
 # Fragments <MigrationBadges :badges="$frontmatter.badges" />
 
-## Overview
+## Overview {#overview}
 
 In Vue 3, components now have official support for multi-root node components, i.e., fragments!
 

--- a/src/ja/recommendations.md
+++ b/src/ja/recommendations.md
@@ -3,7 +3,7 @@
 The supporting libraries for Vue 3 have undergone major updates. Here is a summary of the new default recommendations:
 
 - New versions of Router, Devtools & test utils w/ Vue 3 support
-- Build Toolchain: Vue CLI -> [Vite](https://vitejs.dev/)
+- Build Toolchain: Vue CLI -> [Vite](https://ja.vitejs.dev/)
 - State Management: Vuex -> [Pinia](https://pinia.vuejs.org/)
 - IDE Support: Vetur -> [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
 - New command line TypeScript support: [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc)
@@ -14,7 +14,7 @@ The supporting libraries for Vue 3 have undergone major updates. Here is a summa
 
 ### Build Toolchain
 
-We now recommend [Vite](https://vitejs.dev/) as the new build toolchain for Vue 3 projects. Vite is a new build tool that offers extremely fast server start and hot update performance. It was originally created by the Vue team but is now a cross-framework tool. Learn more about [why we are recommending Vite](https://vitejs.dev/guide/why.html).
+We now recommend [Vite](https://ja.vitejs.dev/) as the new build toolchain for Vue 3 projects. Vite is a new build tool that offers extremely fast server start and hot update performance. It was originally created by the Vue team but is now a cross-framework tool. Learn more about [why we are recommending Vite](https://ja.vitejs.dev/guide/why.html).
 
 You can create a new Vite-powered Vue 3 project via [`create-vue`](https://github.com/vuejs/create-vue), our new scaffolding tool:
 
@@ -27,7 +27,7 @@ While Vue CLI has also been upgraded to support Vue 3, it is now in maintenance 
 - [Vue CLI -> Vite Migration Guide from VueSchool.io](https://vueschool.io/articles/vuejs-tutorials/how-to-migrate-from-vue-cli-to-vite/)
 - [Tools / Plugins that help with auto migration](https://github.com/vitejs/awesome-vite#vue-cli)
 
-Also see [Tooling chapter in new docs](https://vuejs.org/guide/scaling-up/tooling.html).
+Also see [Tooling chapter in new docs](https://ja.vuejs.org/guide/scaling-up/tooling.html).
 
 ### Vue Router
 
@@ -43,7 +43,7 @@ Vue Router 4.0 provides Vue 3 support and has a number of breaking changes of it
 
 - [Documentation](https://pinia.vuejs.org/)
 - [GitHub](https://github.com/vuejs/pinia)
-- [State management chapter in new docs](https://vuejs.org/guide/scaling-up/state-management.html)
+- [State management chapter in new docs](https://ja.vuejs.org/guide/scaling-up/state-management.html)
 
 Vuex 4.0 also provides Vue 3 support with largely the same API as 3.x, and can be used if you have existing Vuex stores that need to be migrated to Vue 3. The only breaking change is [how the plugin is installed](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html#breaking-changes).
 
@@ -64,7 +64,7 @@ The devtools extension has received major updates (released as v6) to support bo
 
 You can now type-check and generate definition files for Vue SFCs from the command line using [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc).
 
-Also see [TypeScript Guide in new docs](https://vuejs.org/guide/typescript/overview.html).
+Also see [TypeScript Guide in new docs](https://ja.vuejs.org/guide/typescript/overview.html).
 
 ### Static Site Generator
 

--- a/src/ja/recommendations.md
+++ b/src/ja/recommendations.md
@@ -1,75 +1,75 @@
-# New Framework-level Recommendations
+# フレームワークレベルでの新しい推奨事項
 
-The supporting libraries for Vue 3 have undergone major updates. Here is a summary of the new default recommendations:
+Vue 3 をサポートするライブラリーが大幅に更新されました。新しいデフォルトの推奨ライブラリーの概要は以下のとおりです:
 
-- New versions of Router, Devtools & test utils w/ Vue 3 support
-- Build Toolchain: Vue CLI -> [Vite](https://ja.vitejs.dev/)
-- State Management: Vuex -> [Pinia](https://pinia.vuejs.org/)
-- IDE Support: Vetur -> [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
-- New command line TypeScript support: [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc)
+- Vue 3 をサポートした Router, Devtools, test utils の新バージョン
+- ビルドツールチェーン: Vue CLI -> [Vite](https://ja.vitejs.dev//)
+- 状態管理: Vuex -> [Pinia](https://pinia.vuejs.org/)
+- IDE サポート: Vetur -> [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+- 新しいコマンドライン TypeScript サポート: [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc)
 - SSG: VuePress -> [VitePress](https://vitepress.vuejs.org/)
 - JSX: `@vue/babel-preset-jsx` -> [`@vue/babel-plugin-jsx`](https://github.com/vuejs/jsx-next)
 
-## Details
+## 詳細
 
-### Build Toolchain
+### ビルドツールチェーン
 
-We now recommend [Vite](https://ja.vitejs.dev/) as the new build toolchain for Vue 3 projects. Vite is a new build tool that offers extremely fast server start and hot update performance. It was originally created by the Vue team but is now a cross-framework tool. Learn more about [why we are recommending Vite](https://ja.vitejs.dev/guide/why.html).
+Vue 3 プロジェクトの新しいビルドツールチェーンとして、[Vite](https://ja.vitejs.dev/) を推奨することになりました。Vite は、非常に高速なサーバー起動とホットアップデートのパフォーマンスを提供する新しいビルドツールです。元々は Vue チームによって作られたものですが、現在はクロスフレームワークのツールとなっています。詳細は [Vite を推奨する理由](https://ja.vitejs.dev/guide/why.html)をご覧ください。
 
-You can create a new Vite-powered Vue 3 project via [`create-vue`](https://github.com/vuejs/create-vue), our new scaffolding tool:
+新しいスキャフォールディングツールである [`create-vue`](https://github.com/vuejs/create-vue) を使って、Vite を搭載した新しい Vue 3 プロジェクトを作成できます:
 
 ```sh
 npm init vue@3
 ```
 
-While Vue CLI has also been upgraded to support Vue 3, it is now in maintenance and no longer recommended for new projects. For information on migrating from Vue CLI to Vite:
+Vue CLI も Vue 3 をサポートするようアップグレードされましたが、現在はメンテナンス中であり、新しいプロジェクトには推奨されなくなりました。Vue CLI から Vite への移行に関する情報はこちら:
 
-- [Vue CLI -> Vite Migration Guide from VueSchool.io](https://vueschool.io/articles/vuejs-tutorials/how-to-migrate-from-vue-cli-to-vite/)
-- [Tools / Plugins that help with auto migration](https://github.com/vitejs/awesome-vite#vue-cli)
+- [VueSchool.io による Vue CLI -> Vite の移行ガイド](https://vueschool.io/articles/vuejs-tutorials/how-to-migrate-from-vue-cli-to-vite/)
+- [自動移行に役立つツールやプラグイン](https://github.com/vitejs/awesome-vite#vue-cli)
 
-Also see [Tooling chapter in new docs](https://ja.vuejs.org/guide/scaling-up/tooling.html).
+[新しいドキュメントのツールガイドの章](https://ja.vuejs.org/guide/scaling-up/tooling.html)も参照してください。
 
 ### Vue Router
 
-Vue Router 4.0 provides Vue 3 support and has a number of breaking changes of its own. Check out its [migration guide](https://router.vuejs.org/guide/migration/index.html) for full details.
+Vue Router 4.0 は Vue 3 のサポートを提供し、多くの破壊的変更があります。詳細については、その[移行ガイド](https://router.vuejs.org/guide/migration/index.html)を確認してください。
 
-- [Documentation](https://router.vuejs.org/)
+- [ドキュメント](https://router.vuejs.org/)
 - [GitHub](https://github.com/vuejs/router)
-- [RFCs](https://github.com/vuejs/rfcs/pulls?q=is%3Apr+is%3Amerged+label%3Arouter)
+- [RFC](https://github.com/vuejs/rfcs/pulls?q=is%3Apr+is%3Amerged+label%3Arouter)
 
-### State Management
+### 状態管理
 
-[Pinia](https://pinia.vuejs.org/) is the new recommended large-scale state management solution. Pinia was created as a prototype for Vuex 5, and has now evolved into the de facto implementation for what we had planned for Vuex 5. We decided to keep its original name in respect of the amount of work that went into it by core team member [Eduardo](https://github.com/posva).
+[Pinia](https://pinia.vuejs.org/) は、新しく推奨される大規模な状態管理ソリューションです。Pinia は Vuex 5 のプロトタイプとして作成されましたが、現在では Vuex 5 で計画していたものの事実上の実装に発展しています。コアチームのメンバーである [Eduardo](https://github.com/posva) による作業量に敬意を表して、元の名前を残すことにしました。
 
-- [Documentation](https://pinia.vuejs.org/)
+- [ドキュメント](https://pinia.vuejs.org/)
 - [GitHub](https://github.com/vuejs/pinia)
-- [State management chapter in new docs](https://ja.vuejs.org/guide/scaling-up/state-management.html)
+- [新しいドキュメントの状態管理の章](https://ja.vuejs.org/guide/scaling-up/state-management.html)
 
-Vuex 4.0 also provides Vue 3 support with largely the same API as 3.x, and can be used if you have existing Vuex stores that need to be migrated to Vue 3. The only breaking change is [how the plugin is installed](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html#breaking-changes).
+Vuex 4.0 は、3.x とほぼ同じ API で Vue 3 もサポートしており、既存の Vuex ストアを Vue 3 に移行する必要がある場合に利用できます。唯一の破壊的変更は、[プラグインのインストール方法](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html#breaking-changes)です。
 
-### IDE Support
+### IDE サポート
 
-[Volar](https://github.com/johnsoncodehk/volar) is now the new official VSCode extension, with greatly improved TypeScript support for Vue SFCs, including full type inference for template expressions.
+[Volar](https://github.com/johnsoncodehk/volar) は、テンプレート式の完全な型推論を含む、Vue SFC の TypeScript サポートが大幅に改善された、新しい公式 VSCode 拡張になりました。
 
-If you have previous installed Vetur, make sure to disable it to avoid conflict with Volar.
+Volar との競合を避けるため、Vetur をインストールしている場合は必ず無効にしてください。
 
-### Devtools Extension
+### Devtools 拡張機能
 
-The devtools extension has received major updates (released as v6) to support both Vue 2 and Vue 3. If you have previously installed v6 via the beta channel, you can remove it and install the extension from the stable channel now.
+Devtools 拡張機能は、Vue 2 と Vue 3 の両方をサポートするためのメジャーアップデート（v6 としてリリース）がありました。以前にベータチャンネル経由で v6 をインストールした場合は、それを削除して、安定版チャンネルから拡張機能をインストールできます。
 
-- [Documentation](https://devtools.vuejs.org/guide/installation.html)
+- [ドキュメント](https://devtools.vuejs.org/guide/installation.html)
 - [GitHub](https://github.com/vuejs/devtools)
 
-### TypeScript Support
+### TypeScript のサポート
 
-You can now type-check and generate definition files for Vue SFCs from the command line using [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc).
+[vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc) を使って、コマンドラインから Vue SFC の型チェックと定義ファイルの生成ができるようになりました。
 
-Also see [TypeScript Guide in new docs](https://ja.vuejs.org/guide/typescript/overview.html).
+[新しいドキュメントの TypeScript ガイド](https://ja.vuejs.org/guide/typescript/overview.html)も参照してください。
 
-### Static Site Generator
+### 静的サイトジェネレーター
 
-[VitePress](https://vitepress.vuejs.org/) is the spiritual successor to VuePress, built on Vue 3 + Vite. It provides a far superior dev experience and also produces faster sites.
+[VitePress](https://vitepress.vuejs.org/) は、VuePress の精神的後継で、Vue 3 + Vite で構築されています。はるかに優れた開発体験を提供し、より高速なサイトを作成できます。
 
 ### JSX
 
-JSX support for Vue 3 is now provided via [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx).
+[`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) によって Vue 3 の JSX サポートが提供されるようになりました。

--- a/src/ja/recommendations.md
+++ b/src/ja/recommendations.md
@@ -1,0 +1,75 @@
+# New Framework-level Recommendations
+
+The supporting libraries for Vue 3 have undergone major updates. Here is a summary of the new default recommendations:
+
+- New versions of Router, Devtools & test utils w/ Vue 3 support
+- Build Toolchain: Vue CLI -> [Vite](https://vitejs.dev/)
+- State Management: Vuex -> [Pinia](https://pinia.vuejs.org/)
+- IDE Support: Vetur -> [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+- New command line TypeScript support: [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc)
+- SSG: VuePress -> [VitePress](https://vitepress.vuejs.org/)
+- JSX: `@vue/babel-preset-jsx` -> [`@vue/babel-plugin-jsx`](https://github.com/vuejs/jsx-next)
+
+## Details
+
+### Build Toolchain
+
+We now recommend [Vite](https://vitejs.dev/) as the new build toolchain for Vue 3 projects. Vite is a new build tool that offers extremely fast server start and hot update performance. It was originally created by the Vue team but is now a cross-framework tool. Learn more about [why we are recommending Vite](https://vitejs.dev/guide/why.html).
+
+You can create a new Vite-powered Vue 3 project via [`create-vue`](https://github.com/vuejs/create-vue), our new scaffolding tool:
+
+```sh
+npm init vue@3
+```
+
+While Vue CLI has also been upgraded to support Vue 3, it is now in maintenance and no longer recommended for new projects. For information on migrating from Vue CLI to Vite:
+
+- [Vue CLI -> Vite Migration Guide from VueSchool.io](https://vueschool.io/articles/vuejs-tutorials/how-to-migrate-from-vue-cli-to-vite/)
+- [Tools / Plugins that help with auto migration](https://github.com/vitejs/awesome-vite#vue-cli)
+
+Also see [Tooling chapter in new docs](https://vuejs.org/guide/scaling-up/tooling.html).
+
+### Vue Router
+
+Vue Router 4.0 provides Vue 3 support and has a number of breaking changes of its own. Check out its [migration guide](https://router.vuejs.org/guide/migration/index.html) for full details.
+
+- [Documentation](https://router.vuejs.org/)
+- [GitHub](https://github.com/vuejs/router)
+- [RFCs](https://github.com/vuejs/rfcs/pulls?q=is%3Apr+is%3Amerged+label%3Arouter)
+
+### State Management
+
+[Pinia](https://pinia.vuejs.org/) is the new recommended large-scale state management solution. Pinia was created as a prototype for Vuex 5, and has now evolved into the de facto implementation for what we had planned for Vuex 5. We decided to keep its original name in respect of the amount of work that went into it by core team member [Eduardo](https://github.com/posva).
+
+- [Documentation](https://pinia.vuejs.org/)
+- [GitHub](https://github.com/vuejs/pinia)
+- [State management chapter in new docs](https://vuejs.org/guide/scaling-up/state-management.html)
+
+Vuex 4.0 also provides Vue 3 support with largely the same API as 3.x, and can be used if you have existing Vuex stores that need to be migrated to Vue 3. The only breaking change is [how the plugin is installed](https://vuex.vuejs.org/guide/migrating-to-4-0-from-3-x.html#breaking-changes).
+
+### IDE Support
+
+[Volar](https://github.com/johnsoncodehk/volar) is now the new official VSCode extension, with greatly improved TypeScript support for Vue SFCs, including full type inference for template expressions.
+
+If you have previous installed Vetur, make sure to disable it to avoid conflict with Volar.
+
+### Devtools Extension
+
+The devtools extension has received major updates (released as v6) to support both Vue 2 and Vue 3. If you have previously installed v6 via the beta channel, you can remove it and install the extension from the stable channel now.
+
+- [Documentation](https://devtools.vuejs.org/guide/installation.html)
+- [GitHub](https://github.com/vuejs/devtools)
+
+### TypeScript Support
+
+You can now type-check and generate definition files for Vue SFCs from the command line using [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/vue-language-tools/vue-tsc).
+
+Also see [TypeScript Guide in new docs](https://vuejs.org/guide/typescript/overview.html).
+
+### Static Site Generator
+
+[VitePress](https://vitepress.vuejs.org/) is the spiritual successor to VuePress, built on Vue 3 + Vite. It provides a far superior dev experience and also produces faster sites.
+
+### JSX
+
+JSX support for Vue 3 is now provided via [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx).


### PR DESCRIPTION
resolves #37

Added Japanese translation

- Modified some configuration files.
- Copy all pages to `src/ja`.
  - Fixed all links to jump to the Japanese version
  - Added anchors only to headings referenced from other pages
- First, translated the "Guide" section (see 806ff223de3675bb62d1c2cd979dd0a66d3d05ad)