### PR TITLE
Information about parent-child migration when removing native modifier

### DIFF
--- a/src/breaking-changes/v-on-native-modifier-removed.md
+++ b/src/breaking-changes/v-on-native-modifier-removed.md
@@ -78,13 +78,13 @@ export default {
 
 A migration strategy taking into account both the parent and the child would be:
 
-1. Keep `.native` in templates until the children are ready to handle native events in the Vue 3 way
+1. Keep `.native` in templates until the children are ready to handle native events in the Vue 3 way.
 2. Migrate the children:
-    1. First, migrate any children that use `$listeners` to use `$attrs` instead (usually used in combination with `inheritAttrs: false`) [more info](listeners-removed.html)
-    2. Document emitted events in child components with `emits: []` [more info](emits-option.html)
-    3. In each of these child components, set INSTANCE_LISTENERS compat behavior to `false` as shown in the example above
+    1. First, migrate any children that use `$listeners` to use `$attrs` instead (usually used in combination with `inheritAttrs: false`) - [more info](listeners-removed.html).
+    2. Document emitted events in child components with `emits: []` - [more info](emits-option.html).
+    3. In each of these child components, set `INSTANCE_LISTENERS` compat behavior to `false` as shown in the example above.
 3. You can now migrate the parents:
-    1. Remove all usage of .native
+    1. Remove all usage of .native.
 
 For a fuller discussion, see this [GitHub issue comment](https://github.com/vuejs/core/issues/4566#issuecomment-917997056).
 

--- a/src/breaking-changes/v-on-native-modifier-removed.md
+++ b/src/breaking-changes/v-on-native-modifier-removed.md
@@ -51,6 +51,43 @@ Consequently, Vue will now add all event listeners that are _not_ defined as com
 
 [Migration build flag: `COMPILER_V_ON_NATIVE`](../migration-build.html#compat-configuration)
 
+## Parent and Child Migration Strategy
+
+If you are running the migration build you will need to consider both the parent and the child component interaction. If you make a parent component use the Vue 3.x syntax by removing `.native` from a child component then the child component must:
+
+- either already be in Vue 3 mode and set `MODE: 3` in compatConfig
+- or must set `INSTANCE_LISTENERS: false` in compatConfig
+
+For example, in a parent component migrated to use 3.x syntax:
+
+```html
+<my-component
+   v-on:click="handleNativeClickEvent"
+/>
+```
+
+Then the corresponding config required in the child `MyComponent.vue` is:
+
+```javascript
+export default {
+  compatConfig: {
+    INSTANCE_LISTENERS: false,
+  }
+}
+```
+
+A migration strategy taking into account both the parent and the child would be:
+
+1. Keep `.native` in templates until the children are ready to handle native events in the Vue 3 way
+2. Migrate the children:
+    1. First, migrate any children that use `$listeners` to use `$attrs` instead (usually used in combination with `inheritAttrs: false`) [more info](listeners-removed.html)
+    2. Document emitted events in child components with `emits: []` [more info](emits-option.html)
+    3. In each of these child components, set INSTANCE_LISTENERS compat behavior to `false` as shown in the example above
+3. You can now migrate the parents:
+    1. Remove all usage of .native
+
+For a fuller discussion, see this [GitHub issue comment](https://github.com/vuejs/core/issues/4566#issuecomment-917997056).
+
 ## See also
 
 - [Relevant RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md#v-on-listener-fallthrough)


### PR DESCRIPTION
This PR implements the documentation suggestion contained within this GitHub issue comment:

https://github.com/vuejs/core/issues/4566#issuecomment-917997056

It explains how to migrate both the parent and child components for the removal of `.native`. In the Vue 3 migration build you also need to update the child to work with this change. This info is currently missing from the docs, but is well explained in the above GitHub comment. Therefore this PR does what is hopefully the obvious and helpful thing, and copies the comment into the docs.