### PR TITLE
Add better resolve alias matching for @vue/compat

### DIFF
--- a/src/migration-build.md
+++ b/src/migration-build.md
@@ -136,7 +136,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
    export default {
      resolve: {
        alias: {
-         vue: '@vue/compat'
+         '^vue$': '@vue/compat'
        }
      },
      plugins: [


### PR DESCRIPTION
The current example needs to be revised since Vite will use the string `vue` to match any import that contains it. (e.g. `import '@vue/server-renderer'` will be transformed to `import '@vue/compat/server-renderer'`