### PR TITLE
chore: remove duplicated breaking change link

### DIFF
--- a/src/breaking-changes/index.md
+++ b/src/breaking-changes/index.md
@@ -22,7 +22,6 @@ While it looks like a lot has changed, a lot of what you know and love about Vue
 ### Components
 
 - [Functional components can only be created using a plain function](./functional-components.html)
-- [`functional` attribute on single-file component (SFC) `<template>` and `functional` component option are deprecated](./functional-components.html)
 - [Async components now require `defineAsyncComponent` method to be created](./async-components.html)
 - [Component events should now be declared with the `emits` option](./emits-option.md)
 


### PR DESCRIPTION
Previous breaking change link explains / redirects to the same url `[Functional components can only be created using a plain function](./functional-components.html)`

Also on **other minor changes** there is another duplicated url reference, but it explains 2 diferent changes:
```
[The data option should always be declared as a function](https://v3-migration.vuejs.org/breaking-changes/data-option)
[The data option from mixins is now merged shallowly](https://v3-migration.vuejs.org/breaking-changes/data-option#mixin-merge-behavior-change)
```