### PR TITLE
Docs: update `WATCH_ARRAY` recommendations to use `deep: 1`

### DIFF
--- a/src/breaking-changes/watch.md
+++ b/src/breaking-changes/watch.md
@@ -23,7 +23,7 @@ watch: {
       console.log('book list changed')
     },
     deep: 1 // Vue 3.5+
-    deep: true // Vue 3.0 - 3.4
+    // deep: true // Vue 3.0 - 3.4
   },
 }
 ```

--- a/src/breaking-changes/watch.md
+++ b/src/breaking-changes/watch.md
@@ -9,6 +9,8 @@ badges:
 ## Overview
 
 - **BREAKING**: When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.
+  - In Vue 3.5+, `deep: 1` should be used, which will trigger on array replacement and array mutation.
+  - Prior to Vue 3.5, `deep: true` can be used, but it will also trigger on deep changes in array elements.
 
 ## 3.x Syntax
 
@@ -20,10 +22,17 @@ watch: {
     handler(val, oldVal) {
       console.log('book list changed')
     },
-    deep: true
+    deep: 1 // Vue 3.5+
+    deep: true // Vue 3.0 - 3.4
   },
 }
 ```
+
+:::warning 
+
+In versions prior to Vue 3.5, watches don't allow setting the [max traversal depth](https://vuejs.org/guide/essentials/watchers.html#deep-watchers), so you're stuck with `deep: true`, which will also trigger the callback on deep modification of array elements.
+
+:::
 
 ## Migration Strategy
 


### PR DESCRIPTION
Vue 3.5 introduces the ability to set the maximum traversal depth on a watch, which allows you to more closely replicate the Vue 2 array watch behavior by setting the depth to 1. This PR updates the migration guide to include `deep: 1` and adds explanations for the version differences.