### PR TITLE
docs: remove COMPILER_V_BIND_PROP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "22"
   NPM_FLAGS = "--version" # prevent Netlify npm install
 
 [build]

--- a/src/ja/migration-build.md
+++ b/src/ja/migration-build.md
@@ -335,7 +335,6 @@ export default {
 | FILTERS                      | ✔    | フィルターは削除されました（このオプションは実行時のフィルター API のみに影響）        | [link](./breaking-changes/filters.html)                                                      |
 | COMPILER_IS_ON_ELEMENT       | ✔    | `is` の使用は `<component>` のみに制限されました                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
 | COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` は引数つきの `v-model` に置き換わりました                    | [link](./breaking-changes/v-model.html)                                                      |
-| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` 修飾子は削除されました                                        |                                                                                             |
 | COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` は順序に依存するようになりました                              | [link](./breaking-changes/v-bind.html)                                                       |
 | COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` 修飾子は削除されました                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
 | COMPILER_V_FOR_REF           | ✔    | `v-for` 内の `ref`（コンパイラーサポート）                                   |                                                                                             |

--- a/src/migration-build.md
+++ b/src/migration-build.md
@@ -337,7 +337,6 @@ Features that start with `COMPILER_` are compiler-specific: if you are using the
 | FILTERS                      | ✔    | Filters removed (this option affects only runtime filter APIs)        | [link](./breaking-changes/filters.html)                                                      |
 | COMPILER_IS_ON_ELEMENT       | ✔    | `is` usage is now restricted to `<component>` only                    | [link](./breaking-changes/custom-elements-interop.html)                                      |
 | COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` replaced by `v-model` with arguments                    | [link](./breaking-changes/v-model.html)                                                      |
-| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` modifier removed                                        |                                                                                             |
 | COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` is now order sensitive                              | [link](./breaking-changes/v-bind.html)                                                       |
 | COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` modifier removed                                        | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
 | COMPILER_V_FOR_REF           | ✔    | `ref` in `v-for` (compiler support)                                   |                                                                                             |

--- a/src/pt/migration-build.md
+++ b/src/pt/migration-build.md
@@ -337,7 +337,6 @@ As funcionalidades que começam com `COMPILER_` são específicas do compilador:
 | FILTERS                      | ✔    | filtros removidos (esta opção afeta apenas as APIs de tempo de execução)      | [ligação](./breaking-changes/filters)                                                      |
 | COMPILER_IS_ON_ELEMENT       | ✔    | o uso de `is` agora está restrito apenas ao `<component>`            | [ligação](./breaking-changes/custom-elements-interop)                                      |
 | COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` substituído por `v-model` com argumentos                 | [ligação](./breaking-changes/v-model)                                                      |
-| COMPILER_V_BIND_PROP         | ✔    | modificador `v-bind.prop` removido                                        |                                                                                             |
 | COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` agora é sensível a ordem                              | [ligação](./breaking-changes/v-bind)                                                       |
 | COMPILER_V_ON_NATIVE         | ✔    | modificador `v-on.native` removido                                        | [ligação](./breaking-changes/v-on-native-modifier-removed)                                 |
 | COMPILER_V_FOR_REF           | ✔    | `ref` no `v-for` (suporte de compilador)                                   |                                                                                             |

--- a/src/uk/migration-build.md
+++ b/src/uk/migration-build.md
@@ -335,7 +335,6 @@ export default {
 | FILTERS                      | ✔    | Фільтри видалено (цей параметр впливає лише на API фільтрів під час виконання) | [link](./breaking-changes/filters.html)                                                      |
 | COMPILER_IS_ON_ELEMENT       | ✔    | Використання `is` обмежено лише до `<component>`                               | [link](./breaking-changes/custom-elements-interop.html)                                      |
 | COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` замінено на `v-model` з аргументами                              | [link](./breaking-changes/v-model.html)                                                      |
-| COMPILER_V_BIND_PROP         | ✔    | Модифікатор `v-bind.prop` видалено                                             |                                                                                              |
 | COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` тепер чутливий до порядку                                    | [link](./breaking-changes/v-bind.html)                                                       |
 | COMPILER_V_ON_NATIVE         | ✔    | Модифікатор `v-on.native` видалено                                             | [link](./breaking-changes/v-on-native-modifier-removed.html)                                 |
 | COMPILER_V_FOR_REF           | ✔    | `ref` в `v-for` (підтримка компілятора)                                             |                                                                                              |

--- a/src/zh/migration-build.md
+++ b/src/zh/migration-build.md
@@ -334,7 +334,6 @@ export default {
 | FILTERS                      | ✔    | 过滤器被移除 (该选项只会影响运行时的过滤器 API) | [链接](./breaking-changes/filters.html) |
 | COMPILER_IS_ON_ELEMENT       | ✔    | `is` 的使用现在被严格限制在 `<component>` 上 | [链接](./breaking-changes/custom-elements-interop.html) |
 | COMPILER_V_BIND_SYNC         | ✔    | `v-bind.sync` 被替换为带参数的 `v-model` | [链接](./breaking-changes/v-model.html) |
-| COMPILER_V_BIND_PROP         | ✔    | `v-bind.prop` 修饰符被移除 | |
 | COMPILER_V_BIND_OBJECT_ORDER | ✔    | `v-bind="object"` 现在是顺序敏感的 | [链接](./breaking-changes/v-bind.html) |
 | COMPILER_V_ON_NATIVE         | ✔    | `v-on.native` 修饰符被移除 | [链接](./breaking-changes/v-on-native-modifier-removed.html) |
 | COMPILER_V_FOR_REF           | ✔    | `v-for` 中的 `ref` (编译器支持)) | |


### PR DESCRIPTION
close https://github.com/vuejs/core/issues/13980

.prop was removed in 3.0. It was reintroduced in 3.2.

[main/changelogs/CHANGELOG-3.2.md#generic](https://github.com/vuejs/core/blob/main/changelogs/CHANGELOG-3.2.md#generic)
https://github.com/vuejs/core/commit/1c7d737cc8ed0384b334d0b3e2dc8ede44906dc4